### PR TITLE
Add user-friendly way to add custom css

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,10 @@ restricted to `#bootstrap-theme`.
 This extension includes an optional file `custom-civicrm.css` which can replace the default
 `civicrm.css`.  This uses the same CSS classes as traditional CiviCRM screens, but the
 look-and-feel matches the Bootstrap look-and-feel.  It is implemented with the same SCSS variables
-and mixins. To use it, figure out the URL for the CSS file:
+and mixins. To use it, navigate to **Administer -> System Settings -> Resource URLs** And click on
+"Shoreditch" as the Custom CSS Url option.
 
-```
-cv url -x shoreditch/css/custom-civicrm.css
-```
-
-And then put this URL in the setting `customCSSURL`, e.g.
+Or from the command line:
 
 ```
 cv api setting.create customCSSURL=$(cv url -x shoreditch/css/custom-civicrm.css --out=list)

--- a/js/urlSettingsForm.js
+++ b/js/urlSettingsForm.js
@@ -7,6 +7,7 @@ CRM.$(function($) {
     .css('width', '100%')
     .wrap('<div style="width:41.4em; display: flex;" />')
     .prop('readonly', url === val)
+    .prop('placeholder', ts('Default CiviCRM style'))
     .before('<div style="white-space: nowrap;"><input type="radio" name="shoreditch-toggle" id="shoreditch-toggle-1" ' + (url === val ? 'checked' : '') + ' /> <label for="shoreditch-toggle-1">Shoreditch</label>' +
       ' &nbsp; <input type="radio" name="shoreditch-toggle" id="shoreditch-toggle-0" ' + (url !== val ? 'checked' : '') + ' /> <label for="shoreditch-toggle-0">' + ts('Other:') + '</label>&nbsp;</div>')
     .parent()
@@ -17,4 +18,11 @@ CRM.$(function($) {
         $('#customCSSURL').val('').prop('readonly', false);
       }
     });
+  // Replace help text with our own
+  $('.crm-url-form-block-customCSSURL .helpicon').removeAttr('onclick').click(function() {
+    CRM.help($('label[for=customCSSURL]').text(), '<p>' +
+      ts('Enabling Shoreditch CSS will change the look and feel of CiviCRM sitewide to give the entire application a consistent modern style.') +
+      '</p>');
+    return false;
+  });
 });

--- a/js/urlSettingsForm.js
+++ b/js/urlSettingsForm.js
@@ -1,0 +1,20 @@
+CRM.$(function($) {
+  'use strict';
+  var url = CRM.vars.shoreditch.cssUrl,
+    val = $('#customCSSURL').val();
+  $('#customCSSURL')
+    .removeClass('huge40')
+    .css('width', '100%')
+    .wrap('<div style="width:41.4em; display: flex;" />')
+    .prop('readonly', url === val)
+    .before('<div style="white-space: nowrap;"><input type="radio" name="shoreditch-toggle" id="shoreditch-toggle-1" ' + (url === val ? 'checked' : '') + ' /> <label for="shoreditch-toggle-1">Shoreditch</label>' +
+      ' &nbsp; <input type="radio" name="shoreditch-toggle" id="shoreditch-toggle-0" ' + (url !== val ? 'checked' : '') + ' /> <label for="shoreditch-toggle-0">' + ts('Other:') + '</label>&nbsp;</div>')
+    .parent()
+    .on('click', 'input:radio', function() {
+      if ($(this).is('#shoreditch-toggle-1')) {
+        $('#customCSSURL').val(url).prop('readonly', true);
+      } else {
+        $('#customCSSURL').val('').prop('readonly', false);
+      }
+    });
+});

--- a/shoreditch.php
+++ b/shoreditch.php
@@ -140,4 +140,11 @@ function shoreditch_civicrm_buildForm($formName) {
     CRM_Core_Resources::singleton()->addScriptFile('org.civicrm.shoreditch', 'js/enable-select2.js');
     CRM_Core_Resources::singleton()->addScriptFile('org.civicrm.shoreditch', 'js/highlight-table-rows.js');
   }
+  elseif ($formName == 'CRM_Admin_Form_Setting_Url') {
+    $baseUrl = CRM_Extension_System::singleton()->getMapper()->keyToUrl('org.civicrm.shoreditch');
+    $cssUrl = CRM_Utils_File::addTrailingSlash($baseUrl, '/') . 'css/custom-civicrm.css';
+    Civi::resources()
+      ->addScriptFile('org.civicrm.shoreditch', 'js/urlSettingsForm.js')
+      ->addVars('shoreditch', array('cssUrl' => $cssUrl));
+  }
 }


### PR DESCRIPTION
Adds an easy gui button in **Administer -> System Settings -> Resource URLs** for the shoreditch custom css file.

![shoreditchcss](https://cloud.githubusercontent.com/assets/2874912/24824112/4f462288-1bd4-11e7-8e94-ef0625c3b514.png)
