### PR TITLE
PCHR-2032: Move outlined buttons styles to a partial

### DIFF
--- a/scss/bootstrap/overrides/style/_buttons.scss
+++ b/scss/bootstrap/overrides/style/_buttons.scss
@@ -103,45 +103,4 @@
   }
 }
 
-.btn-default-outline {
-
-  @include button-outline-variant($crm-white);
-  color: $crm-white !important;
-  border-color: $crm-white !important;
-
-  .open &,
-  &:hover,
-  &:active {
-    background-color: $crm-white !important;
-    color: $crm-dark-blue !important;
-  }
-}
-
-.btn-primary-outline {
-  @include button-outline-variant($btn-primary-bg);
-}
-
-.btn-secondary-outline {
-  @include button-outline-variant($gray-darker, $gray-dark);
-  border-color: $gray-darker !important;
-
-  &:hover {
-    color: #ffffff !important;
-  }
-}
-
-.btn-info-outline {
-  @include button-outline-variant($btn-info-bg);
-}
-
-.btn-success-outline {
-  @include button-outline-variant($btn-success-bg);
-}
-
-.btn-warning-outline {
-  @include button-outline-variant($btn-warning-bg);
-}
-
-.btn-danger-outline {
-  @include button-outline-variant($btn-danger-bg);
-}
+@import "../../variants/outlined-buttons";

--- a/scss/bootstrap/variants/_outlined-buttons.scss
+++ b/scss/bootstrap/variants/_outlined-buttons.scss
@@ -1,0 +1,41 @@
+.btn-default-outline {
+  @include button-outline-variant($crm-white);
+  color: $crm-white !important;
+  border-color: $crm-white !important;
+
+  .open &,
+  &:hover,
+  &:active {
+    background-color: $crm-white !important;
+    color: $crm-dark-blue !important;
+  }
+}
+
+.btn-primary-outline {
+  @include button-outline-variant($btn-primary-bg);
+}
+
+.btn-secondary-outline {
+  @include button-outline-variant($gray-darker, $gray-dark);
+  border-color: $gray-darker !important;
+
+  &:hover {
+    color: #ffffff !important;
+  }
+}
+
+.btn-info-outline {
+  @include button-outline-variant($btn-info-bg);
+}
+
+.btn-success-outline {
+  @include button-outline-variant($btn-success-bg);
+}
+
+.btn-warning-outline {
+  @include button-outline-variant($btn-warning-bg);
+}
+
+.btn-danger-outline {
+  @include button-outline-variant($btn-danger-bg);
+}


### PR DESCRIPTION
## Overview 

This PR moves styles for outlined buttons to a separate file in order to:
1. Make other themes able to include only outlined buttons styles without importing all button styles.
2. Improve the structure of Shoreditch theme.

## Comments

Distributive CSS files are not changed.