### PR TITLE
Don't overlap civicrm-menu on Wordpress

### DIFF
--- a/scss/civicrm/main-menu/_main-menu.scss
+++ b/scss/civicrm/main-menu/_main-menu.scss
@@ -1,7 +1,7 @@
 #civicrm-menu {
   font-family: $font-family-base;
   height: 32px;
-  z-index: 1000;
+  z-index: 99999;
 
   #crm-qsearch {
     background-color: $crm-white !important;


### PR DESCRIPTION
Follow: https://github.com/civicrm/civicrm-core/blob/dce0aa6f40bbfab20782d9c61e9f81e05ac5ce58/css/civicrmNavigation.css#L72