### PR TITLE
Added wordpress admin bar auto-adaptation to civicrm menu

### DIFF
--- a/js/main-menu.js
+++ b/js/main-menu.js
@@ -2,7 +2,20 @@
   $(document).ready(function () {
     amendMarkupOfMenuItemsWithFontAwesomeIcons();
     customizeQuickSearchField();
+    adaptToWordpressAdminBar(); 
   });
+  
+  /**
+   * Adapts civicrm's menu to wordpress' admin bar
+   * Sets civicrm's menu css top to wordpress' admin bar height
+   * It's z-index just above wp admin bar and under civicrm's notification
+   */
+  function adaptToWordpressAdminBar() {
+    if ($('#wpadminbar').length > 0) {
+      $('#civicrm-menu').css('top', $('#wpadminbar').css('height'));
+      $('#civicrm-menu').css('z-index', 999998);
+    }
+  }
 
   /**
    * Amends the markup of any menu item with a FontAwesome icon

--- a/js/main-menu.js
+++ b/js/main-menu.js
@@ -7,12 +7,10 @@
   
   /**
    * Adapts civicrm's menu to wordpress' admin bar
-   * Sets civicrm's menu css top to wordpress' admin bar height
    * It's z-index just above wp admin bar and under civicrm's notification
    */
   function adaptToWordpressAdminBar() {
     if ($('#wpadminbar').length > 0) {
-      $('#civicrm-menu').css('top', $('#wpadminbar').css('height'));
       $('#civicrm-menu').css('z-index', 999998);
     }
   }


### PR DESCRIPTION
Due to excessive z-index on wordpress' admin top bar and side-menu, I suggest adding this little css adaptation when #wpadminbar is detected in the document