### PR TITLE
#160 Use portable resource URL for Custom CSS URL

### DIFF
--- a/shoreditch.php
+++ b/shoreditch.php
@@ -144,7 +144,10 @@ function shoreditch_civicrm_buildForm($formName) {
   }
   elseif ($formName == 'CRM_Admin_Form_Setting_Url') {
     $baseUrl = CRM_Extension_System::singleton()->getMapper()->keyToUrl('org.civicrm.shoreditch');
-    $cssUrl = CRM_Utils_File::addTrailingSlash($baseUrl, '/') . 'css/custom-civicrm.css';
+    $filesVarUrl = '[civicrm.files]/';
+    $filesUrl = Civi::paths()->getUrl($filesVarUrl, 'absolute');
+    $baseVarUrl= str_replace($filesUrl, $filesVarUrl, $baseUrl);
+    $cssUrl = CRM_Utils_File::addTrailingSlash($baseVarUrl, '/') . 'css/custom-civicrm.css';
     Civi::resources()
       ->addScriptFile('org.civicrm.shoreditch', 'js/urlSettingsForm.js')
       ->addVars('shoreditch', array('cssUrl' => $cssUrl));

--- a/shoreditch.php
+++ b/shoreditch.php
@@ -146,7 +146,7 @@ function shoreditch_civicrm_buildForm($formName) {
     $baseUrl = CRM_Extension_System::singleton()->getMapper()->keyToUrl('org.civicrm.shoreditch');
     $filesVarUrl = '[civicrm.files]/';
     $filesUrl = Civi::paths()->getUrl($filesVarUrl, 'absolute');
-    $baseVarUrl= str_replace($filesUrl, $filesVarUrl, $baseUrl);
+    $baseVarUrl = str_replace($filesUrl, $filesVarUrl, $baseUrl);
     $cssUrl = CRM_Utils_File::addTrailingSlash($baseVarUrl, '/') . 'css/custom-civicrm.css';
     Civi::resources()
       ->addScriptFile('org.civicrm.shoreditch', 'js/urlSettingsForm.js')


### PR DESCRIPTION
Before (I manually changed the url to remove the warning):
![screenshot before](https://user-images.githubusercontent.com/9696905/36938167-0bc70664-1f1e-11e8-962b-97f2820ff608.png)

After:
![screenshot after](https://user-images.githubusercontent.com/9696905/36938160-e5fd8020-1f1d-11e8-8da5-2e1e4e4e55ef.png)

See #160
