### PR TITLE
Cannot tell read from unread news items in dashboard

### DIFF
--- a/scss/civicrm/dashboard/pages/_view-dashboard.scss
+++ b/scss/civicrm/dashboard/pages/_view-dashboard.scss
@@ -123,7 +123,7 @@
       .crm-news-feed-item-preview,
       .crm-news-feed-item-title {
         color: $crm-copy;
-        font-weight: $crm-font-weight-h1 !important;
+        font-weight: normal;
       }
     }
 


### PR DESCRIPTION
Overview
-----

In the stock CiviCRM theme, the dashboard shows a list of blog items. The unread items have bold titles. Shoreditch makes them all bold, which breaks usability. My proposed solution is this patch.

Before
----
![screenshot from 2018-04-23 13 05 46](https://user-images.githubusercontent.com/2874912/39141898-1373ab0a-46f7-11e8-90b0-0523043ddd41.png)


After
----
![screenshot from 2018-04-23 13 05 18](https://user-images.githubusercontent.com/2874912/39141905-182806dc-46f7-11e8-801b-6c4ef9959686.png)
