### PR TITLE
PCHR-3635: Fix for #228

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -471,6 +471,14 @@
       "dev": true,
       "requires": {
         "hoek": "2.16.3"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        }
       }
     },
     "brace-expansion": {
@@ -3161,13 +3169,15 @@
         "cryptiles": "2.0.5",
         "hoek": "2.16.3",
         "sntp": "1.0.9"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        }
       }
-    },
-    "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
     },
     "homedir-polyfill": {
       "version": "1.0.1",
@@ -7006,6 +7016,14 @@
       "dev": true,
       "requires": {
         "hoek": "2.16.3"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        }
       }
     },
     "source-map": {


### PR DESCRIPTION
Unfortunately the fix in #228 didn't work, due to the `package-lock.json` file not being updated correctly, thus not making the warning disappear

The problem appears to be on whether `hoek` is listed as a 1st-level property in the lock file: if it is, then GitHub will display the warning. The instructions mentioned in the previous PR are meant to fix this problem, basically resulting in a diff containing this change:

<img width="1439" alt="diff" src="https://user-images.githubusercontent.com/6400898/39370438-2e97be4e-4a3f-11e8-8359-6ac2417cfbec.png">

For some reason the lock file in the previous PR, although changed, didn't contain that particular changes, and thus the problem was not fixed.

Running the instructions again
```bash
npm install hoek && npm uninstall hoek && npm update && npm i 
```
resulted in the lock file contained in this PR, which should fix the issue.

Sanity checks that I've run before submitting the new lock file:
* Reinstalling the modules (`rm -rf node_modules/ && npm i`) doesn't introduce any changes to the lock file
* Running the instructions multiple times (`npm install hoek && npm uninstall hoek && rm -rf node_modules/ && npm i`) doesn't introduce any changes to the lock file
* Installing some new module (`npm install random-js &&  rm -rf node_modules/ &&  npm i`) only introduce changes to the lock file related to the new module