### PR TITLE
SHOR-71: Improve profile pic manipulation logic

### DIFF
--- a/js/contact-summary.js
+++ b/js/contact-summary.js
@@ -1,35 +1,44 @@
 (function () {
-  var profilePicWrapper = '#crm-contact-thumbnail';
-
   document.addEventListener('DOMContentLoaded', function () {
-    usePictureAsBackground();
-    moveUserPictureNextToContactTitle();
+    manipulateProfilePicture();
   });
 
   /**
-   * Moves the user image to the left of the contact name
+   * Performs DOM manipulation on the profile picture element, if present
    */
-  function moveUserPictureNextToContactTitle () {
-    var header = document.querySelector('.crm-summary-contactname-block');
-    var wrapper = document.querySelector(profilePicWrapper);
-    var block = document.querySelector('.crm-summary-block');
+  function manipulateProfilePicture () {
+    var picWrapper = document.querySelector('#crm-contact-thumbnail');
 
-    header.insertBefore(wrapper, block);
-  }
+    if (!picWrapper) {
+      return;
+    }
 
-  /**
-   * Makes the user picture the background image of the <a>
-   * element that links to the picture itself
-   *
-   * Having it as a background allows for support of different
-   * picture ratios that would otherwise get stretched with a <img> element
-   */
-  function usePictureAsBackground () {
-    var wrapper = document.querySelector(profilePicWrapper);
-    var picture = wrapper.querySelector('.crm-contact_image');
-    var src = picture.querySelector('img').getAttribute('src');
+    usePictureAsBackground();
+    moveUserPictureNextToContactTitle();
 
-    picture.querySelector('a').style.backgroundImage = 'url(' + src + ')';
-    picture.querySelector('a').removeChild(picture.querySelector('img'));
+    /**
+     * Moves the picture to the left of the contact name
+     */
+    function moveUserPictureNextToContactTitle () {
+      var header = document.querySelector('.crm-summary-contactname-block');
+      var block = document.querySelector('.crm-summary-block');
+
+      header.insertBefore(picWrapper, block);
+    }
+
+    /**
+     * Makes the picture the background image of the <a>
+     * element that links to the picture itself
+     *
+     * Having it as a background allows for support of different
+     * picture ratios that would otherwise get stretched with a <img> element
+     */
+    function usePictureAsBackground () {
+      var picture = picWrapper.querySelector('.crm-contact_image');
+      var src = picture.querySelector('img').getAttribute('src');
+
+      picture.querySelector('a').style.backgroundImage = 'url(' + src + ')';
+      picture.querySelector('a').removeChild(picture.querySelector('img'));
+    }
   }
 }());


### PR DESCRIPTION
The new version of contact-summary.js written as part of #285 was assuming that there is always a profile picture in the contact summary page, which is not really the case. As a result when the picture was missing, it would throw an error

<img width="1439" alt="error" src="https://user-images.githubusercontent.com/6400898/45471877-c10e7c80-b732-11e8-8048-108bba2bf1e3.png">

A simple guard prevents the issue
```js
function manipulateProfilePicture () {
  var picWrapper = document.querySelector('#crm-contact-thumbnail');

  if (!picWrapper) {
    return;
  }

  usePictureAsBackground();
  moveUserPictureNextToContactTitle();
}
```
The script has also been refactored a little to remove code duplication