### PR TITLE
BASW-340: Fixed top margin for body with adminimal_admin_menu module class

### DIFF
--- a/scss/civicrm/common/_base.scss
+++ b/scss/civicrm/common/_base.scss
@@ -11,10 +11,13 @@
         margin-top: $crm-main-menu-height !important;
       }
 
+      // These rules are needed to fix the visual issue produced by Adminimal Menu module: it removes body top-margin but adds `body::before{height: 29px;...}`.
+      // That causes Civicrm menu overlap the header which looks badly.
+      // @see /sites/all/modules/contrib/adminimal_admin_menu/adminimal_admin_menu.css line 95.
       &.admin-menu.adminimal-menu {
         margin-top: $crm-main-menu-height !important;
 
-        &::after {
+        &::before {
           content: none;
         }
       }

--- a/scss/civicrm/common/_base.scss
+++ b/scss/civicrm/common/_base.scss
@@ -11,6 +11,14 @@
         margin-top: $crm-main-menu-height !important;
       }
 
+      &.admin-menu.adminimal-menu {
+        margin-top: $crm-main-menu-height !important;
+
+        &::after {
+          content: none;
+        }
+      }
+
       .toolbar-menu {
         height: $crm-main-menu-height !important;
         padding-bottom: 0 !important;


### PR DESCRIPTION
Civicrm menu was overlapping the header because adminimal_admin_menu module breakes body top margin. Now it fixed.

Before:
![image](https://user-images.githubusercontent.com/39520000/49937288-16a42200-fef8-11e8-863a-4451237a129d.png)

After:
![image](https://user-images.githubusercontent.com/39520000/49937683-5a4b5b80-fef9-11e8-9baf-3ff9eb873253.png)
