### PR TITLE
SHOR-105: Fix Contact Custom Data Tab

### DIFF
--- a/scss/civicrm/contact/pages/_view-contact.scss
+++ b/scss/civicrm/contact/pages/_view-contact.scss
@@ -43,16 +43,16 @@
 
         table.crm-info-panel {
           border: 0;
-        }
 
-        table.crm-info-panel td {
-          color: $crm-copy;
-          vertical-align: middle;
-        }
+          td {
+            color: $crm-copy;
+            vertical-align: middle;
 
-        table.crm-info-panel td.label {
-          color: $gray-darker;
-          font-weight: $crm-font-weight-h1;
+            &.label {
+              color: $gray-darker;
+              font-weight: $crm-font-weight-h1;
+            }
+          }
         }
       }
 

--- a/scss/civicrm/contact/pages/_view-contact.scss
+++ b/scss/civicrm/contact/pages/_view-contact.scss
@@ -35,6 +35,10 @@
           .crm-hover-button:first-child {
             padding-left: 0;
           }
+
+          .crm-i {
+            vertical-align: baseline;
+          }
         }
 
         table.crm-info-panel {

--- a/scss/civicrm/contact/pages/_view-contact.scss
+++ b/scss/civicrm/contact/pages/_view-contact.scss
@@ -29,6 +29,14 @@
           border-radius: 0 0 $panel-border-radius $panel-border-radius !important;
         }
 
+        .crm-submit-buttons {
+          padding: 0;
+
+          .crm-hover-button:first-child {
+            padding-left: 0;
+          }
+        }
+
         table.crm-info-panel {
           border: 0;
           border-bottom: 1px solid $crm-background;

--- a/scss/civicrm/contact/pages/_view-contact.scss
+++ b/scss/civicrm/contact/pages/_view-contact.scss
@@ -43,11 +43,6 @@
 
         table.crm-info-panel {
           border: 0;
-          border-bottom: 1px solid $crm-background;
-
-          &:last-child {
-            border-bottom: 0;
-          }
         }
 
         table.crm-info-panel td {

--- a/scss/civicrm/contact/pages/_view-contact.scss
+++ b/scss/civicrm/contact/pages/_view-contact.scss
@@ -47,10 +47,6 @@
           color: $gray-darker;
           font-weight: $crm-font-weight-h1;
         }
-
-        table.crm-info-panel td.html-adjust {
-          width: 100%;
-        }
       }
 
       table.no-border td {


### PR DESCRIPTION
## Overview
This PR fixes the custom data data displayed on the contact details. The table is not expanded properly due to an outdated CSS rule. Also, the alignment of the delete action button has been fixed.

## Before
<img width="892" alt="screen shot 2019-01-08 at 10 36 22 pm" src="https://user-images.githubusercontent.com/1642119/50872385-dc625f00-1395-11e9-9998-423f1ed3ec4f.png">


## After
<img width="1022" alt="screen shot 2019-01-10 at 10 52 58 am" src="https://user-images.githubusercontent.com/1642119/50976290-fb600e80-14c5-11e9-9e36-155876e0f255.png">



## How to reproduce
* Create a custom field group for contacts.
* Add new fields to that custom field group.
* Open any contact and view their details.
* Click on the tab with the name of the new custom field group.

## Technical Details

The problem is that the following rule:

```scss
table.crm-info-panel td.html-adjust {
  width: 100%;
}
```

Overrides the natural width of the column. The label column is `150px` and the value column would take up the rest, but if `width: 100%` is specified the column would try to take as much space as possible and break the label column's width.

This rule was first introduced in the following PR for an old CiviCRM version:
https://github.com/compucorp/civihr/pull/1598

Also, the alignment of the actions button was fixed by removing the padding from their container and removing the padding left of the first button:

```scss
.crm-submit-buttons {
  padding: 0;

  .crm-hover-button:first-child {
    padding-left: 0;
  }
}
```

Also, the icon for the button was aligned to the baseline so it's symmetrical in relation to its companion text:

```scss
.crm-submit-buttons 
  .crm-i {
    vertical-align: baseline;
  }
}
```

The border rules for the custom fields table have also been removed.

## Tests

Ran Backstop tests from the [Backstop Config](https://github.com/compucorp/backstopjs-config) repo. No changes were detected to the contact page tabs covered by the scenarios.

It's important to note that the custom field set tab was tested manually since there are no scenarios covering these type of tabs. A new scenario was not submitted to Backstop Config since this is very specific and requires multiple pre existing data.