### PR TITLE
SHOR-106: Fix margins for contact's participation custom fields

### DIFF
--- a/scss/civicrm/contact/pages/_events.scss
+++ b/scss/civicrm/contact/pages/_events.scss
@@ -367,9 +367,11 @@
   }
 
   [id*='Food_Preference'] {
+    padding: 0;
+
     .crm-accordion-wrapper {
-      margin-left: -40px;
-      margin-right: -40px;
+      margin-left: 0;
+      margin-right: 0;
 
       .crm-accordion-body {
         padding: 20px 43px !important;

--- a/scss/civicrm/contact/pages/_events.scss
+++ b/scss/civicrm/contact/pages/_events.scss
@@ -281,6 +281,11 @@
       margin: 0 -20px;
     }
 
+    .crm-accordion-wrapper {
+      margin-left: 0;
+      margin-right: 0;
+    }
+
     .td {
       line-height: 18px !important;
     }

--- a/scss/civicrm/contact/pages/_events.scss
+++ b/scss/civicrm/contact/pages/_events.scss
@@ -366,7 +366,15 @@
     top: 5px;
   }
 
-  [id*='Food_Preference'] {
+  table#info,
+  .crm-event-participantview-form-block-fee_amount table,
+  table.selector {
+    @include expandable-table;
+    box-shadow: none !important;
+  }
+
+  // custom fields
+  .section-shown {
     padding: 0;
 
     .crm-accordion-wrapper {
@@ -388,13 +396,6 @@
     .html-adjust {
       width: 100%;
     }
-  }
-
-  table#info,
-  .crm-event-participantview-form-block-fee_amount table,
-  table.selector {
-    @include expandable-table;
-    box-shadow: none !important;
   }
 }
 


### PR DESCRIPTION
## Overview
This PR fixes the following issues with custom fields for the contact's events tab:

* margins for the accordion title inside when creating a new event participation for the contact.
* The styles of the custom fields when viewing the participation.

## Before
### Creating a new event participation
![admin example com shor 9600](https://user-images.githubusercontent.com/1642119/51158012-cd2d5680-1858-11e9-9674-3a23a4144662.png)

### Viewing an existing participation
![admin example com shor 9600 2](https://user-images.githubusercontent.com/1642119/51280647-940af880-19b6-11e9-9cae-58336918e859.png)

## After
### Creating a new event participation
<img width="928" alt="screen shot 2019-01-14 at 11 59 24 pm" src="https://user-images.githubusercontent.com/1642119/51157928-7b84cc00-1858-11e9-85c0-73d5844768ba.png">


### Viewing an existing participation
<img width="955" alt="screen shot 2019-01-16 at 5 41 48 pm" src="https://user-images.githubusercontent.com/1642119/51280448-0929fe00-19b6-11e9-9e58-e94878152e25.png">

## Technical details

### When creating a new event participation
Since the events form is a custom form with custom markup and css rules compared to those of other forms, the negative margin added here:
https://github.com/reneolivo/org.civicrm.shoreditch/blob/988ec9756af56a7cfa9940853ea2bc48f6cdace0/scss/civicrm/contact/pages/_events.scss#L281

Is removed for accordion wrappers:

```scss
.crm-accordion-wrapper {
  margin-left: 0;
  margin-right: 0;
}
```

### When viewing an existing event participation
The PR that first introduced the changes for the participation view modal is this one:
https://github.com/compucorp/civihr/pull/1639

The form has changed since then and the margin for the accordion headers was changed from `-40px` to `0px`:

```scss
[id*='Food_Preference'] {
  .crm-accordion-wrapper {
      margin-left: -40px;
      margin-right: -40px;
  }
}
```

Also, the `[id*='Food_Preference']` selector and all of its nested rules were changed to `.section-shown` since the former only assumes the fixes should be applied to the food preference custom fields, but the later fixes all issues for all custom fields.

## Tests

Backstops tests ran successfully.