### PR TITLE
SHOR-108: Show all contact actions

### DIFF
--- a/scss/civicrm/contact/_tooltip.scss
+++ b/scss/civicrm/contact/_tooltip.scss
@@ -27,13 +27,6 @@
       margin-left: 175px;
       margin-right: 175px;
       width: 175px;
-
-      .crm-action-new-case,
-      .crm-action-new-relationship,
-      .crm-action-new-note,
-      .crm-action-tag-contact {
-        display: none;
-      }
     }
 
     .crm-contact_print-list {


### PR DESCRIPTION
## Overview

This PR displays all contact actions that were previously hidden for CiviHR.

## Before
<img width="561" alt="screen shot 2019-01-16 at 7 23 13 pm" src="https://user-images.githubusercontent.com/1642119/51285123-3da4b680-19c4-11e9-8413-162bd0301187.png">
`Add Case`, `Add Relationship`, `Add Note`, and `Tag Contact` are missing.


## After
<img width="564" alt="screen shot 2019-01-16 at 7 20 47 pm" src="https://user-images.githubusercontent.com/1642119/51285106-3382b800-19c4-11e9-950e-89f7b428ee8d.png">

## Technical details

The issue happened when merging missing CiviHR fixes into Shoreditch in this PR:
https://github.com/civicrm/org.civicrm.shoreditch/pull/1

The changes were necessary, but the one removing the contact actions was too specific for CiviHR and was not needed by Shoreditch. These particular changes were removed:

```scss
 .crm-action-new-case,
 .crm-action-new-relationship,
 .crm-action-new-note,
 .crm-action-tag-contact {
   display: none;
 }
```

## Tests

Backstop tests for the contact page ran successfully.