### PR TITLE
BASW-376: Fix shadows of tables on Contribution tab

### DIFF
--- a/scss/civicrm/contact/pages/_contributions.scss
+++ b/scss/civicrm/contact/pages/_contributions.scss
@@ -543,6 +543,10 @@
   .crm-contact-contribute-recur-active {
     margin-bottom: 13px;
   }
+
+  .crm-contact-contribute-recur {
+    @include civicrm-table-with-header;
+  }
 }
 
 .CRM_Contribute_Form_Contribution {

--- a/scss/civicrm/contact/pages/_memberships.scss
+++ b/scss/civicrm/contact/pages/_memberships.scss
@@ -106,19 +106,23 @@
     }
   }
 
-  #memberships table td {
-    &:not(:last-child) {
-      max-width: 85px;
-      overflow: hidden;
-      padding: 15px 10px 15px 20px;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
+  #memberships {
+    @include civicrm-table-with-header();
 
-    &:nth-child(2),
-    &:nth-child(3),
-    &:nth-child(4) {
-      max-width: 100px;
+    table td {
+      &:not(:last-child) {
+        max-width: 85px;
+        overflow: hidden;
+        padding: 15px 10px 15px 20px;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      &:nth-child(2),
+      &:nth-child(3),
+      &:nth-child(4) {
+        max-width: 100px;
+      }
     }
   }
 

--- a/scss/civicrm/mixins/_civicrm-table.scss
+++ b/scss/civicrm/mixins/_civicrm-table.scss
@@ -46,3 +46,24 @@
     }
   }
 }
+
+
+/*
+ * Styles a table with a H3 header:
+ * - removes shadows from the table and the header
+ * - adds a shadow to their wrapper
+ * - removes unnecessary borders from the column headers
+ */
+@mixin civicrm-table-with-header() {
+  box-shadow: $box-shadow;
+
+  h3,
+  table {
+    box-shadow: none !important;
+  }
+
+  .columnheader {
+    border: 0 !important;
+    border-bottom: 1px solid $crm-grayblue-dark !important;
+  }
+}


### PR DESCRIPTION
## Overview

This PR fixes the issue with shadows on the Contribution tab.

## Before

Notice overlayed shadows:
![image](https://user-images.githubusercontent.com/3973243/51844256-b5e87180-230c-11e9-9bdf-0e58e82840ac.png)

Notice the extra thick shadow on the table header:
![image](https://user-images.githubusercontent.com/3973243/51844280-c26cca00-230c-11e9-8e4a-330c38b7ed18.png)

## After

![image](https://user-images.githubusercontent.com/3973243/51846890-686f0300-2312-11e9-880c-6b6a123cba24.png)

![image](https://user-images.githubusercontent.com/3973243/51844171-8174b580-230c-11e9-97cc-253428a908b5.png)

## Technical description

We add a mixin that supports this layout: H3 + Table in a Wrapper. We remove shadows from tables and headers and apply a solid shadow on the wrapper.

```css
@mixin civicrm-table-with-header() {
  box-shadow: $box-shadow;

  h3,
  table {
    box-shadow: none !important;
  }

  .columnheader {
    border: 0 !important;
    border-bottom: 1px solid $crm-grayblue-dark !important;
  }
}
```

## Comments

It was considered to:

1) find a universal style, but unfortunately there is no distinctive and reliable way to apply needed styles to only needed table due to inconsistency of markup.
2) change the markup - this is too complicated and will require changing markup in several extensions and also core.

## Tests

All changes in this PR are isolated to specific components/extensions, so manual tests were done. BackstopJS was run as well.