### PR TITLE
BASW-379: Fix CiviCRM action item icons

### DIFF
--- a/scss/civicrm/common/_buttons.scss
+++ b/scss/civicrm/common/_buttons.scss
@@ -189,6 +189,10 @@ $button-border-radius: 2px;
     @extend %btn;
   }
 
+  .crm-hover-button.crm-i {
+    font-family: $font-family-fontawesome !important;
+  }
+
   input[type=button],
   a.button,
   a.button:link,


### PR DESCRIPTION
## Overview

This PR fixes the issue with actions icons in CiviCRM.

## Before

![image](https://user-images.githubusercontent.com/3973243/52709311-503eeb00-2f84-11e9-95e0-03c3c90d7b6e.png)

## After

![image](https://user-images.githubusercontent.com/3973243/52709256-2c7ba500-2f84-11e9-9a63-98790942e9bd.png)

## Technical description

The problem is at *scss/civicrm/common/_buttons.scss*:

```
...
.crm-hover-button,
... {
  @extend %btn;
}
```

The `%btn` changes the font to `OpenSans` while it should be kept as `FontAwesome` but only for icons, so:

```
.crm-hover-button.crm-i {
  font-family: $font-family-fontawesome !important;
  // !important is needed because %btn contains !important too
}
```

is a safe way to keep the font correct and do not produce regressions.

## Tests

This is an extremely minor change, so only **manual** tests were performed to save time.