### PR TITLE
BASW-377: Fix styles in new contribution modal

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -4,6 +4,6 @@ In order to make sure that your work does not introduce regression issues or une
 
 The styleguide provides you with a page that showcases the entire base Bootstrap theme + custom modifiers in a single page, so that you can check how they look like in Shoreditch and how your changes affect the theme and its components.
 
-To run BackstopJS on the styleguide, follows the [instructions](https://github.com/compucorp/org.civicrm.styleguide/blob/staging/README.md#backstopjs) included in the extension. Make sure to always use BackstopJS on the styleguide whenever you work on `bootstrap.css`.
+To run BackstopJS on the styleguide, follows the [instructions](https://github.com/compucorp/org.civicrm.styleguide/blob/master/README.md#backstopjs) included in the extension. Make sure to always use BackstopJS on the styleguide whenever you work on `bootstrap.css`.
 
 To run BackstopJS on the existing core screens, you can temporarily use [this setup](https://github.com/compucorp/backstopjs-config). Of course this should be used only if you are introducing changes to `custom-civicrm.css`.

--- a/scss/civicrm/_variables.scss
+++ b/scss/civicrm/_variables.scss
@@ -32,6 +32,8 @@ $crm-min-lg-width: 1505px;
 $crm-sm-th-width: 200px;
 $crm-sm-input-width: 100px;
 
+$crm-table-label-column-width: 150px;
+
 $crm-status-bar-no-top: 0 20px 20px;
 $crm-status-bar-no-bottom: 20px 20px 0;
 

--- a/scss/civicrm/_variables.scss
+++ b/scss/civicrm/_variables.scss
@@ -1,5 +1,7 @@
 /* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type, selector-max-id */
 
+$crm-standard-gap: 20px;
+
 $contact-avatar: 90px;
 $crm-control-height: 30px;
 

--- a/scss/civicrm/administer/settings/_extensions.scss
+++ b/scss/civicrm/administer/settings/_extensions.scss
@@ -35,7 +35,7 @@
               width: auto;
 
               &.label {
-                width: 150px;
+                width: $crm-table-label-column-width;
               }
             }
           }

--- a/scss/civicrm/common/_alerts.scss
+++ b/scss/civicrm/common/_alerts.scss
@@ -10,3 +10,7 @@
 .status-warning {
   color: $brand-danger !important;
 }
+
+.messages.no-popup > .icon:first-of-type + p {
+  margin-top: 0;
+}

--- a/scss/civicrm/common/_base.scss
+++ b/scss/civicrm/common/_base.scss
@@ -302,7 +302,6 @@ a.sorting_desc {
   &::after {
     position: absolute;
     right: 0;
-    top: 3px;
   }
 }
 
@@ -316,4 +315,8 @@ a.sorting_asc::after {
 
 a.sorting_desc::after {
   @include fa-icon($font-size-base, $fa-var-sort-desc, $brand-primary);
+}
+
+.crm-expand-row {
+  line-height: 1em;
 }

--- a/scss/civicrm/common/_modals.scss
+++ b/scss/civicrm/common/_modals.scss
@@ -21,6 +21,11 @@
 
 .ui-dialog-content {
   table {
+    // @NOTE This selector is used for nested accordions
+    td[colspan='2'] {
+      padding: 0;
+    }
+
     &.no-border {
       margin: 0;
       width: 100%;

--- a/scss/civicrm/common/_modals.scss
+++ b/scss/civicrm/common/_modals.scss
@@ -18,3 +18,74 @@
     }
   }
 }
+
+.ui-dialog-content {
+  table {
+    &.no-border {
+      margin: 0;
+      width: 100%;
+    }
+
+    &.crm-info-panel {
+      background: transparent;
+      border: 0;
+      box-shadow: none !important;
+      font-family: $font-family-base;
+
+      th,
+      td {
+        background-color: transparent !important;
+        border-bottom: 1px solid $crm-background !important;
+        color: $gray-darker !important;
+      }
+    }
+  }
+
+  thead.sticky {
+    border-bottom: 1px solid $crm-background !important;
+  }
+
+  td.label {
+    padding-left: $crm-standard-gap;
+  }
+
+  .crm-accordion-header,
+  .crm-info-panel,
+  .dataTables_wrapper {
+    margin: 0 -#{$crm-standard-gap};
+  }
+
+  .crm-accordion-wrapper {
+    margin: 0 !important;
+  }
+
+  .form-item,
+  .crm-accordion-wrapper {
+    padding: 0;
+  }
+
+  .crm-accordion-body {
+    padding: 0 !important;
+  }
+
+  .crm-info-panel {
+    width: calc(100% + #{$crm-standard-gap * 2});
+  }
+
+  .crm-accordion-header:not(.crm-master-accordion-header)+.crm-accordion-body {
+    box-shadow: none;
+    padding: 0 !important;
+
+    td {
+      padding-left: $crm-standard-gap;
+    }
+  }
+
+  .dataTables_length {
+    padding: $crm-standard-gap;
+  }
+
+  .dataTables_wrapper {
+    box-shadow: none;
+  }
+}

--- a/scss/civicrm/common/_modals.scss
+++ b/scss/civicrm/common/_modals.scss
@@ -77,7 +77,8 @@
       padding-left: $crm-standard-gap;
     }
 
-    .form-layout-compressed {
+    .form-layout-compressed,
+    table.selector {
       margin-top: $crm-standard-gap;
     }
   }

--- a/scss/civicrm/common/_modals.scss
+++ b/scss/civicrm/common/_modals.scss
@@ -135,7 +135,7 @@
         }
       }
 
-      &:not(.crm-info-panel) {
+      &:not(.crm-info-panel):not(.form-layout-compressed):not(.form-layout) {
         td {
           padding: $crm-standard-gap;
         }

--- a/scss/civicrm/common/_modals.scss
+++ b/scss/civicrm/common/_modals.scss
@@ -99,6 +99,14 @@
     padding: $crm-standard-gap;
   }
 
+  .crm-accordion-body {
+    .dataTables_wrapper:first-child {
+      .dataTables_length {
+        padding-top: 0;
+      }
+    }
+  }
+
   .dataTables_wrapper {
     box-shadow: none;
   }

--- a/scss/civicrm/common/_modals.scss
+++ b/scss/civicrm/common/_modals.scss
@@ -93,7 +93,7 @@
     box-shadow: none;
     padding: 20px 0 !important;
 
-    td {
+    td.label {
       padding-left: $crm-standard-gap;
     }
 

--- a/scss/civicrm/common/_modals.scss
+++ b/scss/civicrm/common/_modals.scss
@@ -114,7 +114,7 @@
     }
 
     > table,
-    > div > table {
+    > div:not(.dataTables_wrapper) > table {
       margin: 0 -#{$crm-standard-gap};
       width: calc(100% + #{$crm-standard-gap * 2});
 

--- a/scss/civicrm/common/_modals.scss
+++ b/scss/civicrm/common/_modals.scss
@@ -76,6 +76,10 @@
     td {
       padding-left: $crm-standard-gap;
     }
+
+    .form-layout-compressed {
+      margin-top: $crm-standard-gap;
+    }
   }
 
   .dataTables_length {

--- a/scss/civicrm/common/_modals.scss
+++ b/scss/civicrm/common/_modals.scss
@@ -44,6 +44,10 @@
         color: $gray-darker !important;
         padding-right: $crm-standard-gap;
       }
+
+      tr:last-of-type td {
+        border: 0 !important;
+      }
     }
   }
 
@@ -74,16 +78,19 @@
     width: calc(100% + #{$crm-standard-gap * 2});
   }
 
+  .crm-form-block {
+    margin-bottom: 0;
+  }
+
   .crm-accordion-header:not(.crm-master-accordion-header)+.crm-accordion-body {
     box-shadow: none;
-    padding: 0 !important;
+    padding: 20px 0 !important;
 
     td {
       padding-left: $crm-standard-gap;
     }
 
-    .form-layout-compressed,
-    table.selector {
+    .form-layout-compressed {
       margin-top: $crm-standard-gap;
     }
   }

--- a/scss/civicrm/common/_modals.scss
+++ b/scss/civicrm/common/_modals.scss
@@ -20,6 +20,10 @@
 }
 
 .ui-dialog-content {
+  .messages.no-popup {
+    margin-bottom: $crm-standard-gap;
+  }
+
   table {
     // @NOTE This selector is used for nested accordions
     td[colspan='2'] {

--- a/scss/civicrm/common/_modals.scss
+++ b/scss/civicrm/common/_modals.scss
@@ -112,6 +112,35 @@
         padding-top: 0;
       }
     }
+
+    > table,
+    > div > table {
+      margin: 0 -#{$crm-standard-gap};
+      width: calc(100% + #{$crm-standard-gap * 2});
+
+      th,
+      td {
+        line-height: 1.5em;
+      }
+
+      th {
+        background: $gray-lighter;
+        border: 0;
+        color: $gray-darker;
+        padding: 15px $crm-standard-gap;
+        vertical-align: middle;
+
+        div {
+          padding: 0;
+        }
+      }
+
+      &:not(.crm-info-panel) {
+        td {
+          padding: $crm-standard-gap;
+        }
+      }
+    }
   }
 
   .dataTables_wrapper {

--- a/scss/civicrm/common/_modals.scss
+++ b/scss/civicrm/common/_modals.scss
@@ -113,7 +113,7 @@
       }
     }
 
-    > table,
+    > table:not(.form-layout):not(.form-layout-compressed),
     > div:not(.dataTables_wrapper) > table {
       margin: 0 -#{$crm-standard-gap};
       width: calc(100% + #{$crm-standard-gap * 2});

--- a/scss/civicrm/common/_modals.scss
+++ b/scss/civicrm/common/_modals.scss
@@ -26,8 +26,11 @@
 
   table {
     // @NOTE This selector is used for nested accordions
-    td[colspan='2'] {
-      padding: 0;
+    &.form-layout,
+    &.form-layout-compressed {
+      > tbody > tr > td[colspan='2'] {
+        padding: 0;
+      }
     }
 
     &.no-border {

--- a/scss/civicrm/common/_modals.scss
+++ b/scss/civicrm/common/_modals.scss
@@ -37,6 +37,7 @@
         background-color: transparent !important;
         border-bottom: 1px solid $crm-background !important;
         color: $gray-darker !important;
+        padding-right: $crm-standard-gap;
       }
     }
   }
@@ -62,10 +63,6 @@
   .form-item,
   .crm-accordion-wrapper {
     padding: 0;
-  }
-
-  .crm-accordion-body {
-    padding: 0 !important;
   }
 
   .crm-info-panel {

--- a/scss/civicrm/contact/_detail.scss
+++ b/scss/civicrm/contact/_detail.scss
@@ -752,10 +752,6 @@
     }
   }
 
-  table {
-    width: 100%;
-  }
-
   .crm-button_qf_Contribution_upload {
     margin-left: 0;
   }

--- a/scss/civicrm/contact/pages/_batch.scss
+++ b/scss/civicrm/contact/pages/_batch.scss
@@ -194,7 +194,7 @@
         .crm-form-date-wrapper {
           display: inline-block;
           // Necessary to make sure the calendar icon addon has enough
-          // space to be displayed next to the input field 
+          // space to be displayed next to the input field
           width: 255px;
         }
       }
@@ -206,7 +206,7 @@
       [class*='crm-batch-join_date-'],
       [class*='crm-batch-membership_'] {
         display: block;
-        width: 150px !important;
+        width: $crm-table-label-column-width !important;
 
         .crm-clear-link {
           margin-left: -5px !important;

--- a/scss/civicrm/contact/pages/_contributions.scss
+++ b/scss/civicrm/contact/pages/_contributions.scss
@@ -551,10 +551,6 @@
     font-weight: $crm-font-weight-h1 !important;
   }
 
-  &#Contribution .crm-accordion-body {
-    padding: 15px 20px !important;
-  }
-
   .crm-submit-buttons {
     .crm-button_qf_Contribution_upload {
       margin-left: 0 !important;
@@ -735,88 +731,6 @@
     display: none;
   }
 
-  table {
-    background: transparent;
-    border: 0;
-    box-shadow: none !important;
-    font-family: $font-family-base;
-    margin: 10px 0;
-
-    thead tr {
-      border: 1px solid $crm-background !important;
-
-      th {
-        background: $gray-lighter !important;
-        border: 0;
-        color: $gray-darker !important;
-        height: 42px;
-        line-height: 1.1em;
-        vertical-align: middle;
-
-        div {
-          padding: 0;
-        }
-      }
-    }
-
-    tbody tr {
-      background: $crm-white;
-      border: 1px solid $crm-background;
-      border-left: 0;
-      border-right: 0;
-
-      &.crm-child-row {
-        > td {
-          padding: 0;
-
-          .crm-ajax-container table {
-            margin: 0;
-
-            tbody {
-              border-top: 1px solid $crm-grayblue-dark !important;
-            }
-          }
-
-          .crm-ajax-container table th {
-            background: $gray-lighter !important;
-            border: 0;
-            color: $gray-darker;
-            vertical-align: middle;
-          }
-        }
-      }
-
-      td {
-        background: $crm-white !important;
-        border: 0;
-        line-height: 1.1em;
-        padding: 20px;
-
-        &.label {
-          border-bottom: 0;
-          color: $gray-darker !important;
-          vertical-align: middle;
-
-          div {
-            padding: 0;
-          }
-        }
-
-        &:not(.label) {
-          color: $gray-dark;
-        }
-      }
-
-      &:last-child {
-        border-bottom: 0;
-      }
-
-      &:first-child {
-        border-top: 0;
-      }
-    }
-  }
-
   #paymentDetails_Information {
     .helpicon {
       left: 0;
@@ -828,61 +742,12 @@
     }
   }
 
-  #Donor_Information__ {
-    padding: 0;
-
-    .crm-accordion-body {
-      padding: 20px 40px !important;
-    }
-  }
-
-  .crm-accordion-header {
-    font-family: $font-family-base;
-    font-size: 13px !important;
-
-    + .crm-accordion-body {
-      padding: 20px !important;
-
-      td.label {
-        padding-left: 0 !important;
-      }
-    }
-  }
-
   label[for='thankyou_date'] {
     top: 7px;
   }
 
   label[for='thankyou_date_time'] {
     top: 5px;
-  }
-}
-
-#ContributionView {
-  [id*='Donor_Information_'] {
-    padding: 0;
-
-    .crm-accordion-wrapper .crm-accordion-body {
-      padding: 20px 43px !important;
-    }
-
-    td {
-      box-sizing: border-box;
-      display: table-cell;
-      min-width: 170px;
-      vertical-align: middle;
-    }
-
-    .html-adjust {
-      width: 100%;
-    }
-  }
-
-  .crm-submit-buttons {
-    a.button {
-      background-color: #0071bd;
-      margin-bottom: 29px;
-    }
   }
 }
 

--- a/scss/civicrm/contact/pages/_contributions.scss
+++ b/scss/civicrm/contact/pages/_contributions.scss
@@ -105,7 +105,7 @@
 
     .dateplugin {
       margin-bottom: 5px;
-      max-width: 150px;
+      max-width: $crm-table-label-column-width;
     }
 
     .addon.fa-calendar {
@@ -360,7 +360,7 @@
 
     .pay-later_info-section {
       .label {
-        width: 150px;
+        width: $crm-table-label-column-width;
       }
 
       .content {

--- a/scss/civicrm/contact/pages/_events.scss
+++ b/scss/civicrm/contact/pages/_events.scss
@@ -251,10 +251,10 @@
     width: 100%;
   }
 
-  .crm-event-eventfees-form-block-payment_information {
-    fieldset {
-      margin: 10px -4px 0;
-    }
+  .crm-event-eventfees-form-block-payment_information fieldset,
+  #payment_information fieldset,
+  .crm-event-form-fee-block + fieldset {
+    margin: 0 -#{$crm-standard-gap};
   }
 
   .crm-event-eventfees-form-block-contribution_status_id,

--- a/scss/civicrm/contact/pages/_events.scss
+++ b/scss/civicrm/contact/pages/_events.scss
@@ -298,38 +298,6 @@
 
 
 #ParticipantView {
-  .crm-event-participant-view-form-block {
-    margin: 0 -20px;
-  }
-
-  table {
-    tbody tr {
-      &.crm-event-participantview-form-block-displayName td {
-        div {
-          float: right;
-        }
-      }
-
-      td {
-        line-height: 18px;
-      }
-    }
-
-    &.crm-info-panel {
-      tr {
-        td {
-          &:first-child {
-            padding-left: 20px;
-          }
-
-          &:last-child {
-            padding-right: 20px;
-          }
-        }
-      }
-    }
-  }
-
   .description {
     padding: 20px;
   }
@@ -342,19 +310,6 @@
     td:not(.label) {
       padding: 0;
       width: 100%;
-    }
-  }
-
-  .crm-accordion-header {
-    font-family: $font-family-base;
-    font-size: $font-size-base !important;
-
-    + .crm-accordion-body {
-      padding: 20px !important;
-
-      td.label {
-        padding-left: 0 !important;
-      }
     }
   }
 

--- a/scss/civicrm/contact/pages/_events.scss
+++ b/scss/civicrm/contact/pages/_events.scss
@@ -277,15 +277,6 @@
 
 #{civi-dialog()} {
   #Participant {
-    .view-content {
-      margin: 0 -20px;
-    }
-
-    .crm-accordion-wrapper {
-      margin-left: 0;
-      margin-right: 0;
-    }
-
     .td {
       line-height: 18px !important;
     }

--- a/scss/civicrm/contact/pages/_memberships.scss
+++ b/scss/civicrm/contact/pages/_memberships.scss
@@ -232,8 +232,6 @@
   }
 
   .crm-membership-form-block {
-    padding: 0 !important;
-
     .auto-renew-text {
       display: block;
       padding: $crm-status-bar-no-top;

--- a/scss/civicrm/contact/pages/_memberships.scss
+++ b/scss/civicrm/contact/pages/_memberships.scss
@@ -7,7 +7,7 @@
     box-shadow: $box-shadow;
     margin-bottom: 20px;
 
-    .dataTables_wrapper {
+    /*.dataTables_wrapper {
       box-shadow: none;
     }
 
@@ -103,7 +103,7 @@
           }
         }
       }
-    }
+    }*/
   }
 
   #memberships table td {
@@ -389,172 +389,6 @@
 .CRM_Member_Form_MembershipView {
   .action-link {
     display: none;
-  }
-
-  .crm-membership-view-form-block {
-    padding: 0 !important;
-
-    .crm-block {
-      padding: 0;
-    }
-  }
-
-  table {
-    background: transparent;
-    border: 0;
-    box-shadow: none !important;
-    font-family: $font-family-base;
-
-    &.crm-info-panel {
-      margin-left: -20px;
-      margin-right: -20px;
-      margin-top: -20px;
-      width: 105%;
-    }
-
-    &.no-border {
-      margin-left: -20px;
-      margin-right: -20px;
-      width: calc(100% + 40px);
-    }
-
-    thead {
-      tr {
-        border: 1px solid $crm-background !important;
-
-        th {
-          background: $gray-lighter !important;
-          border: 0;
-          border-bottom: 0;
-          color: $gray-darker !important;
-          height: 42px;
-          line-height: 1.1em;
-          vertical-align: middle;
-
-          div {
-            padding: 0;
-          }
-        }
-      }
-    }
-
-    tbody {
-      tr {
-        background: $crm-white;
-        border: 1px solid $crm-background !important;
-        border-left: 0;
-        border-right: 0;
-
-        &.crm-child-row {
-          > td {
-            padding: 0;
-
-            .crm-ajax-container {
-              table {
-                margin: 0;
-
-                tbody {
-                  border-top: 1px solid $crm-grayblue-dark !important;
-                }
-
-                th {
-                  background: $gray-lighter !important;
-                  border: 0;
-                  border-bottom: 0;
-                  color: $gray-darker;
-                  vertical-align: middle;
-                }
-              }
-            }
-          }
-        }
-
-        td {
-          background: $crm-white !important;
-          border: 0;
-          line-height: 1.1em;
-          padding: 20px;
-
-          &.label {
-            border-bottom: 0;
-            color: $gray-darker !important;
-            vertical-align: middle;
-
-            div {
-              padding: 0;
-            }
-          }
-
-          &:not(.label) {
-            color: $gray-dark;
-          }
-        }
-
-        td.section-shown {
-          padding: 0 20px;
-        }
-
-        &:last-child {
-          border-bottom: 0;
-        }
-
-        &:first-child {
-          border-top: 0;
-        }
-      }
-    }
-  }
-
-  .crm-accordion-wrapper {
-    padding: 0;
-
-    .crm-accordion-header {
-      background: $crm-background !important;
-    }
-
-    .crm-accordion-body {
-      padding: 0 !important;
-
-      > p {
-        &.description {
-          padding: 0 20px;
-        }
-      }
-
-      tr {
-        th {
-          padding: 10px 20px !important;
-        }
-
-        td.label {
-          background: none !important;
-          padding: 10px 30px !important;
-        }
-      }
-    }
-  }
-
-  .section-shown .crm-info-panel {
-    margin: 0;
-    width: 100%;
-
-    tr td.label {
-      background: $crm-white !important;
-      padding: 10px 30px !important;
-    }
-  }
-
-  #related-contacts-memberships {
-    margin-left: -20px;
-    margin-right: -20px;
-
-    h3 {
-      background: $crm-background;
-    }
-
-    .dataTables_wrapper {
-      margin-bottom: 0;
-    }
   }
 }
 

--- a/scss/civicrm/contact/pages/_memberships.scss
+++ b/scss/civicrm/contact/pages/_memberships.scss
@@ -724,3 +724,9 @@
 #{civi-page('member')} .CRM_Member_Form_Search h3:first-of-type {
   margin-top: 0;
 }
+
+// Adhoc: fixes the <h3> margin
+#related-contacts-memberships > h3 {
+  box-shadow: none;
+  margin: 0 -#{$crm-standard-gap};
+}

--- a/scss/civicrm/contact/pages/_memberships.scss
+++ b/scss/civicrm/contact/pages/_memberships.scss
@@ -133,12 +133,6 @@
     }
   }
 
-  .crm-contact-contribute-contributions {
-    margin: 0 -#{$crm-standard-gap};
-    overflow-x: scroll;
-    width: calc(100% + #{$crm-standard-gap * 2});
-  }
-
   .crm-membership-form-block {
     .auto-renew-text {
       display: block;

--- a/scss/civicrm/contact/pages/_memberships.scss
+++ b/scss/civicrm/contact/pages/_memberships.scss
@@ -133,6 +133,12 @@
     }
   }
 
+  .crm-contact-contribute-contributions {
+    margin: 0 -#{$crm-standard-gap};
+    overflow-x: scroll;
+    width: calc(100% + #{$crm-standard-gap * 2});
+  }
+
   .crm-membership-form-block {
     .auto-renew-text {
       display: block;

--- a/scss/civicrm/contact/pages/_memberships.scss
+++ b/scss/civicrm/contact/pages/_memberships.scss
@@ -6,104 +6,6 @@
     border-radius: $panel-border-radius;
     box-shadow: $box-shadow;
     margin-bottom: 20px;
-
-    /*.dataTables_wrapper {
-      box-shadow: none;
-    }
-
-    table {
-      background: transparent;
-      border: 0;
-      border-radius: 0 0 $panel-border-radius $panel-border-radius;
-      font-family: $font-family-base;
-
-      thead tr {
-        border-bottom: 1px solid $crm-grayblue-dark;
-
-        th {
-          background: $gray-lighter;
-          border: 0;
-          color: $gray-darker;
-          line-height: 1.5em;
-          padding: 15px 20px;
-          vertical-align: middle;
-
-          div {
-            padding: 0;
-          }
-        }
-      }
-
-      tbody tr {
-        background: transparent;
-        border-left: 0;
-        border-right: 0;
-        border-top: 1px solid $crm-background;
-
-        td {
-          background: $crm-white;
-          border: 0;
-          color: $gray-dark;
-          line-height: 1.5em;
-          padding: 15px 20px;
-          vertical-align: middle;
-
-          &:last-child {
-            padding-left: 10px;
-            text-align: right;
-            width: 84px;
-
-            span {
-              display: inline-block;
-            }
-          }
-
-          .btn-slide {
-            padding-right: 0 !important;
-            text-indent: -9999px;
-            width: 7px;
-
-            &::after,
-            .panel {
-              text-indent: 0;
-            }
-          }
-
-          a,
-          span.btn-slide {
-            color: $brand-primary !important;
-            text-transform: none;
-
-            &:hover {
-              background: none;
-            }
-
-            a {
-              color: $crm-copy !important;
-
-              &:hover {
-                background: none;
-              }
-            }
-          }
-        }
-
-        &:last-child {
-          border-bottom-left-radius: $border-radius-base;
-          border-bottom-right-radius: $border-radius-base;
-
-          td {
-            &:first-child {
-              border-bottom-left-radius: $border-radius-base;
-            }
-
-            &:last-child {
-              border-bottom-right-radius: $border-radius-base;
-            }
-          }
-        }
-      }
-    }*/
   }
 
   #memberships table td {
@@ -573,7 +475,7 @@
       td .dateplugin {
         display: inline-block;
         font-weight: normal;
-        max-width: 150px;
+        max-width: $crm-table-label-column-width;
       }
     }
   }

--- a/scss/civicrm/contact/pages/_memberships.scss
+++ b/scss/civicrm/contact/pages/_memberships.scss
@@ -278,12 +278,6 @@
       }
     }
   }
-
-  .no-popup {
-    p {
-      margin: 0;
-    }
-  }
 }
 
 .CRM_Member_Form_MembershipView {

--- a/scss/civicrm/contact/pages/_new-activity.scss
+++ b/scss/civicrm/contact/pages/_new-activity.scss
@@ -119,14 +119,6 @@
     }
   }
 
-  .crm-activity-form-block-attachment,
-  .crm-activity-form-block-recurring_activity,
-  .crm-activity-form-block-schedule_followup {
-    > td {
-      padding: 0;
-    }
-  }
-
   #recurring-entity-block,
   #follow-up {
     .crm-accordion-body {

--- a/scss/civicrm/contact/pages/_new-individual.scss
+++ b/scss/civicrm/contact/pages/_new-individual.scss
@@ -18,7 +18,7 @@
       .contact_basic_information-section tr {
         &:first-child td {
           &:last-child {
-            min-width: 150px;
+            min-width: $crm-table-label-column-width;
           }
 
           &:first-child {

--- a/scss/civicrm/contact/pages/_relationships.scss
+++ b/scss/civicrm/contact/pages/_relationships.scss
@@ -120,21 +120,6 @@
       }
     }
   }
-
-  .ui-dialog .crm-relationship-view-block {
-    margin-bottom: -20px;
-    margin-left: -20px;
-    margin-right: -20px;
-
-    table tbody td {
-      line-height: 1.5em;
-      padding: 7px 20px !important;
-    }
-
-    table tbody td label {
-      font-weight: 600;
-    }
-  }
 }
 
 .CRM_Contact_Form_Relationship {


### PR DESCRIPTION
## Overview

This PR fixes appearance of contents inside modals. In a nutshell, it removes "per-page" code applied to "fix" the issues with the content, then applies global fixes, then applies _some_ "per-page" code where fixing globally is not viable.

## Before

The Recurring Contributions "view" modal looks totally broken:

![image](https://user-images.githubusercontent.com/3973243/52966006-1c0d6500-339e-11e9-9c33-218136cf2680.png)

![image](https://user-images.githubusercontent.com/3973243/52966022-23347300-339e-11e9-8516-02ce37155cb8.png)

## After

![image](https://user-images.githubusercontent.com/3973243/52966226-a8b82300-339e-11e9-9add-546cdea2c8f4.png)

![image](https://user-images.githubusercontent.com/3973243/53005711-b10a6f80-342b-11e9-99e1-412a90f3dfbe.png)

## More information

This PR applies new global styling for modals and their contents, thus a lot of modals now look slightly different, in a good way. This GIF is a very long one but it shows all modals and proves that global styling works:

![modals](https://user-images.githubusercontent.com/3973243/53006504-39d5db00-342d-11e9-981d-0f2b67febd40.gif)

## Technical Details

### Global modals style

At first, we created a new global style that applies to all modals and removed "per-page" styles related to modals, that fixed the initial screen that you see in Before/After sections and also other modals:

*scss/civicrm/common/_modals.scss*

```css
.ui-dialog-content {
  table {
    // ... global styles
```
There is just too much code to represent all in the snippet, so please refer to https://github.com/civicrm/org.civicrm.shoreditch/pull/363/files#diff-0508f2f5f60a92bc722462d514631b68 for more info.

### Message icon fix

```css
.messages.no-popup > .icon:first-of-type + p {
  margin-top: 0;
}
```
Makes the paragraph aligned with an icon.

#### Before

![image](https://user-images.githubusercontent.com/3973243/53013617-1c5d3d00-343e-11e9-95b9-660c14821029.png)

#### After

![image](https://user-images.githubusercontent.com/3973243/53013582-0bacc700-343e-11e9-8057-cfb5625bd23e.png)


### Per-page fixes

```css
.crm-contact-contribute-contributions {
  margin: 0 -#{$crm-standard-gap};
  overflow-x: scroll;
  width: calc(100% + #{$crm-standard-gap * 2});
}
```
Fixes table in Memberships tab so it scrolls horizontally and does not get out of bounds of the modal.

#### Before

![1](https://user-images.githubusercontent.com/3973243/53013808-82e25b00-343e-11e9-8596-6cb103982c7e.gif)

#### After

![2](https://user-images.githubusercontent.com/3973243/53013822-8aa1ff80-343e-11e9-9098-6542dd7a9ffe.gif)

### Nested accordion selector

This one may look weird, but there is no other way to identify this `<TD>`:

```css
&.form-layout,
  &.form-layout-compressed {
    > tbody > tr > td[colspan='2'] {
      padding: 0;
```
We need to reset paddings to fix nested accordions:

![image](https://user-images.githubusercontent.com/3973243/53012724-c1c2e180-343b-11e9-954b-8f6348a921db.png)

Unfortunately, the accordions are **inside** the `<TD>`s and there is no such CSS technique to select them, so we assume that if is `colspan=2` and it is not nested, then it is made for an accordion.

![image](https://user-images.githubusercontent.com/3973243/53012822-00f13280-343c-11e9-8793-997b8c236498.png)

### Carets

Because we removed some "per-page" styles, we needed to align carets properly. Good news is that now we get rid of these ad-hocs like "top: 2px":

#### Before

![image](https://user-images.githubusercontent.com/3973243/53102354-62d89780-3523-11e9-8b8a-c6b24983c6d6.png)

#### After

![image](https://user-images.githubusercontent.com/3973243/53108638-46425c80-352f-11e9-9ce8-add68edbba6d.png)

## Tests

✅Manual Tests - passed (tested modals and random pages for accidental artifacts)
✅BackstopJS - passed

## QA round 1

We have a style for tables inside accordion body (needs negative margin):

```css
.crm-accordion-body {
    ...

    > table,
    > div > table {
      margin: 0 -#{$crm-standard-gap};
```
The problem is that for the data tables (class `.dataTable`) this should not be applied hence they already have wrappers that have negative margin.

![image](https://user-images.githubusercontent.com/3973243/54121735-23e78480-43f3-11e9-8672-a3f3aaefb0cf.png)

So we need to exclude this wrapper:

```css
.crm-accordion-body {
    ...

    > table,
    > div:not(.dataTables_wrapper) > table { ...
```

![image](https://user-images.githubusercontent.com/3973243/54121964-b12ad900-43f3-11e9-9969-aade3f5176bf.png)

Same with `.form-layout` and `.form-layout-compressed`.

Also, as per @jamienovick suggestion, we should not scroll tables horizontally in modals.

### Edit Event adhoc

The markup for the Edit Events is custom and needs to be treated separately:

![image](https://user-images.githubusercontent.com/3973243/54143009-ccf8a400-4420-11e9-8b13-0e9f8f27fd45.png)

```css
.crm-event-eventfees-form-block-payment_information fieldset,
  #payment_information fieldset,
  .crm-event-form-fee-block + fieldset {
    margin: 0 -#{$crm-standard-gap};
  }
```

