### PR TITLE
BASW-375: Adhoc the legend header for Memberships

### DIFF
--- a/scss/civicrm/_variables.scss
+++ b/scss/civicrm/_variables.scss
@@ -1,5 +1,7 @@
 /* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type, selector-max-id */
 
+$crm-standard-gap: 20px;
+
 $contact-avatar: 90px;
 $crm-control-height: 30px;
 

--- a/scss/civicrm/contact/pages/_memberships.scss
+++ b/scss/civicrm/contact/pages/_memberships.scss
@@ -279,6 +279,10 @@
             }
           }
         }
+
+        #recordContribution {
+          margin-top: $crm-standard-gap;
+        }
       }
     }
 


### PR DESCRIPTION
## Overview

This PR simply adds a padding to the header on the New Membership screen.

## Before

![image](https://user-images.githubusercontent.com/3973243/53254012-6e11fb80-36ba-11e9-9721-64f11589d092.png)

## After

![image](https://user-images.githubusercontent.com/3973243/53254461-50916180-36bb-11e9-8c16-8bb8c58327e4.png)

## Technical Details

```
#recordContribution {
  margin-top: $crm-standard-gap;
```

Please note `$crm-standard-gap: 20px;` variable exists in BASW-377, so we duplicate it in this PR to reuse.

## Tests

The form was tested manually.