### PR TITLE
Style contact tab counts to look like badges

### DIFF
--- a/scss/civicrm/contact/_tabs.scss
+++ b/scss/civicrm/contact/_tabs.scss
@@ -163,16 +163,36 @@
       background: $crm-background;
       border: 0;
 
-      a,
-      em {
+      a {
         color: $brand-primary !important;
       }
     }
 
-    a,
-    em {
+    a {
       color: $gray-darker !important;
       cursor: default;
+    }
+
+    em {
+      background: $brand-primary;
+      border-radius: 10px;
+      color: $crm-white !important;
+      display: inline-block;
+      float: right;
+      margin-left: 5px;
+      min-width: 10px;
+      padding: 0 5px;
+      text-align: center;
+
+      &:empty {
+        display: none;
+      }
+    }
+
+    &.crm-count-0 {
+      em {
+        background: $crm-gray-matte;
+      }
     }
   }
 


### PR DESCRIPTION
This styles the counters in the vertical tabs follow the bootstrap convention of [badges](https://getbootstrap.com/docs/3.3/components/#badges).

- Empty count will disappear
- Count of 0 will be grey
- Count > 0 will be primary color

![screenshot from 2019-02-28 10-19-57](https://user-images.githubusercontent.com/2874912/53576885-a85c1c80-3b42-11e9-9376-67a426dd1990.png)
