### PR TITLE
SHOR-122: Style CiviRules extension

### DIFF
--- a/scss/civicrm/_mixins.scss
+++ b/scss/civicrm/_mixins.scss
@@ -2,6 +2,7 @@
 
 @import 'mixins/accordion';
 @import 'mixins/advanced-multiselect';
+@import 'mixins/block-form';
 @import 'mixins/border-box';
 @import 'mixins/calc';
 @import 'mixins/civicrm-form-control';

--- a/scss/civicrm/_mixins.scss
+++ b/scss/civicrm/_mixins.scss
@@ -21,5 +21,6 @@
 @import 'mixins/section-title';
 @import 'mixins/table-block';
 @import 'mixins/table-header';
+@import 'mixins/table-selector';
 @import 'mixins/transform';
 @import 'mixins/translate';

--- a/scss/civicrm/_variables.scss
+++ b/scss/civicrm/_variables.scss
@@ -1,5 +1,7 @@
 /* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type, selector-max-id */
 
+$crm-standard-gap: 20px;
+
 $contact-avatar: 90px;
 $crm-control-height: 30px;
 

--- a/scss/civicrm/common/_base.scss
+++ b/scss/civicrm/common/_base.scss
@@ -227,6 +227,19 @@
       width: 50%;
     }
   }
+
+  /**
+   * @NOTE the table that goes straight after <h3> does not
+   * need a shadow because in that case the shadow falls onto the <h3>.
+   * The shadow instead is applied
+   * to the *container* of the <h3> and <table>.dataTables_wrapper
+   *
+   * @TODO remove all the .dataTables_wrapper { box-shadow: none; }
+   * from "per-page" styles and other files
+   */
+  h3 + .dataTables_wrapper {
+    box-shadow: none;
+  }
 }
 
 .page-civicrm {

--- a/scss/civicrm/common/_base.scss
+++ b/scss/civicrm/common/_base.scss
@@ -302,7 +302,12 @@ a.sorting_desc {
   &::after {
     position: absolute;
     right: 0;
-    top: 3px;
+  }
+
+  &:not(.sorting) {
+    &::after {
+      top: 3px;
+    }
   }
 }
 

--- a/scss/civicrm/common/_forms.scss
+++ b/scss/civicrm/common/_forms.scss
@@ -328,3 +328,11 @@ input.error {
     border-color: $input-border-focus;
   }
 }
+
+// Add this class to style a form inside a container
+// like you see at /civicrm/civirule/form/rule?reset=1&action=add
+.crm-form-block-container {
+  .crm-form-block {
+    @include block-form();
+  }
+}

--- a/scss/civicrm/common/_tables.scss
+++ b/scss/civicrm/common/_tables.scss
@@ -198,7 +198,10 @@ table {
     td,
     th {
       border: 0 !important;
+      line-height: 1.5em !important;
+      padding-bottom: #{$crm-standard-gap / 4 * 3} !important;
       padding-left: $crm-standard-gap !important;
+      padding-top: #{$crm-standard-gap / 4 * 3} !important;
 
       &:last-of-type {
         padding-right: $crm-standard-gap !important;

--- a/scss/civicrm/common/_tables.scss
+++ b/scss/civicrm/common/_tables.scss
@@ -183,29 +183,4 @@ table {
       }
     }
   }
-
-  table.selector {
-    background-color: $crm-white;
-
-    thead th {
-      background-color: $gray-light !important;
-    }
-
-    tbody tr:not(:last-of-type) {
-      border-bottom: solid 1px $gray-light !important;
-    }
-
-    td,
-    th {
-      border: 0 !important;
-      line-height: 1.5em !important;
-      padding-bottom: #{$crm-standard-gap / 4 * 3} !important;
-      padding-left: $crm-standard-gap !important;
-      padding-top: #{$crm-standard-gap / 4 * 3} !important;
-
-      &:last-of-type {
-        padding-right: $crm-standard-gap !important;
-      }
-    }
-  }
 }

--- a/scss/civicrm/common/_tables.scss
+++ b/scss/civicrm/common/_tables.scss
@@ -183,4 +183,23 @@ table {
       }
     }
   }
+
+  table.selector {
+    background-color: $crm-white;
+
+    thead tr,
+    tbody tr:not(:last-of-type) {
+      border-bottom: solid 1px $gray-light !important;
+    }
+
+    td,
+    th {
+      border: 0 !important;
+      padding-left: $crm-standard-gap !important;
+
+      &:last-of-type {
+        padding-right: $crm-standard-gap !important;
+      }
+    }
+  }
 }

--- a/scss/civicrm/common/_tables.scss
+++ b/scss/civicrm/common/_tables.scss
@@ -187,7 +187,10 @@ table {
   table.selector {
     background-color: $crm-white;
 
-    thead tr,
+    thead th {
+      background-color: $gray-light !important;
+    }
+
     tbody tr:not(:last-of-type) {
       border-bottom: solid 1px $gray-light !important;
     }

--- a/scss/civicrm/contact/_contact.scss
+++ b/scss/civicrm/contact/_contact.scss
@@ -47,3 +47,4 @@ $page-class-name: str_slice($page-class, 2);
 @import 'pages/change-log';
 @import 'pages/pledges';
 @import 'pages/find-contacts';
+@import 'pages/rules';

--- a/scss/civicrm/contact/pages/_memberships.scss
+++ b/scss/civicrm/contact/pages/_memberships.scss
@@ -7,10 +7,6 @@
     box-shadow: $box-shadow;
     margin-bottom: 20px;
 
-    .dataTables_wrapper {
-      box-shadow: none;
-    }
-
     table {
       background: transparent;
       border: 0;

--- a/scss/civicrm/contact/pages/_rules.scss
+++ b/scss/civicrm/contact/pages/_rules.scss
@@ -85,7 +85,8 @@
 
   // "CiviRules Edit Condition parameters" pages
   &.page-civicrm-civirule-form-condition-datachangedcomparison,
-  &.page-civicrm-civirule-form-condition-datacomparison {
+  &.page-civicrm-civirule-form-condition-datacomparison,
+  &.page-civicrm-civirule-form-condition-activity-contact-record-type {
     .crm-form-block {
       @include block-form();
     }
@@ -101,8 +102,16 @@
   padding-bottom: 0 !important;
   padding-top: 0 !important;
 
-  + fieldset table.selector {
-    @include table-selector();
+  + fieldset {
+    table.selector {
+      @include table-selector();
+    }
+
+    // This div is empty on the screen, it contains a <ul> which does not have
+    // any child elements inside. Thus, we remove it.
+    #alpha-filter {
+      display: none;
+    }
   }
 }
 

--- a/scss/civicrm/contact/pages/_rules.scss
+++ b/scss/civicrm/contact/pages/_rules.scss
@@ -1,0 +1,12 @@
+/* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type, selector-max-id */
+
+.page-civicrm-civirule {
+
+  // "CiviRules Add Rule" page
+  .CRM_Civirules_Form_Rule {
+    .crm-civirule-rule_label-block,
+    .crm-civirule-trigger-block {
+      @include block-form();
+    }
+  }
+}

--- a/scss/civicrm/contact/pages/_rules.scss
+++ b/scss/civicrm/contact/pages/_rules.scss
@@ -82,6 +82,14 @@
       width: 20px;
     }
   }
+
+  // "CiviRules Edit Condition parameters" pages
+  &.page-civicrm-civirule-form-condition-datachangedcomparison,
+  &.page-civicrm-civirule-form-condition-datacomparison {
+    .crm-form-block {
+      @include block-form();
+    }
+  }
 }
 
 // "Find CiviRules Rules" page

--- a/scss/civicrm/contact/pages/_rules.scss
+++ b/scss/civicrm/contact/pages/_rules.scss
@@ -45,7 +45,7 @@
   }
 
   // "CiviRules Add Condition", "CiviRules Add Action" and
-  // "CiviRules Edit Action parameters" pages
+  // "CiviRules Edit Action Parameters" pages
   &.page-civicrm-civirule-form-rule-condition,
   &.page-civicrm-civirule-form-rule-action,
   &.page-civicrm-civirule-form-action {
@@ -73,4 +73,19 @@
       width: 20px;
     }
   }
+}
+
+// "Find CiviRules Rules" page
+// This is the only reliable selector for this page because it is built as a
+// Custom Search page and it does not contain any Rules extension specific classes
+#civirule_helptext_dialog-block + .crm-form-block {
+  @include block-form();
+  padding-bottom: 0 !important;
+
+  padding-top: 0 !important;
+}
+
+// Help icon in "Description" column on "Find CiviRules Rules" results page
+#civirule_help_text_icon {
+  margin-left: $crm-standard-gap / 4;
 }

--- a/scss/civicrm/contact/pages/_rules.scss
+++ b/scss/civicrm/contact/pages/_rules.scss
@@ -1,11 +1,9 @@
 /* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type, selector-max-id */
 
 .page-civicrm-civirule {
-
   // "CiviRules Add Rule" and "CiviRules Update Rule" pages
   .CRM_Civirules_Form_Rule {
-    .crm-civirule-rule_label-block,
-    .crm-civirule-trigger-block {
+    .crm-civirule-rule_label-block {
       @include block-form();
     }
 
@@ -42,19 +40,6 @@
       // so we remove the top border to eliminate the border duplication.
       .crm-submit-buttons {
         border-top: 0;
-      }
-    }
-
-    // Only one trigger can be specified, thus, flush table styling
-    #civirule-triggerBlock-table {
-      tr {
-        background-color: transparent !important;
-      }
-
-      td {
-        border-bottom: 0;
-        padding-bottom: 0;
-        padding-top: 0;
       }
     }
   }

--- a/scss/civicrm/contact/pages/_rules.scss
+++ b/scss/civicrm/contact/pages/_rules.scss
@@ -26,7 +26,11 @@
           border-bottom: solid 1px $gray-light;
           color: $crm-black;
           padding-left: $crm-standard-gap;
-          padding-right: $crm-standard-gap;
+          padding-right: 0;
+
+          &:last-of-type {
+            padding-right: $crm-standard-gap;
+          }
         }
 
         tr {

--- a/scss/civicrm/contact/pages/_rules.scss
+++ b/scss/civicrm/contact/pages/_rules.scss
@@ -43,4 +43,11 @@
       }
     }
   }
+
+  // "CiviRules Add Condition" page
+  &.page-civicrm-civirule-form-rule-condition {
+    .crm-civirule-rule_condition-block {
+      @include block-form();
+    }
+  }
 }

--- a/scss/civicrm/contact/pages/_rules.scss
+++ b/scss/civicrm/contact/pages/_rules.scss
@@ -51,4 +51,16 @@
       @include block-form();
     }
   }
+
+  // "CiviRules Add Action" page
+  &.page-civicrm-civirule-form-rule-action {
+    #XWeekDay_time_hour {
+      text-align: right;
+    }
+
+    #XWeekDay_time_hour,
+    #XWeekDay_time_minute {
+      width: 20px;
+    }
+  }
 }

--- a/scss/civicrm/contact/pages/_rules.scss
+++ b/scss/civicrm/contact/pages/_rules.scss
@@ -43,6 +43,14 @@
         border-top: 0;
       }
     }
+
+    // Fix for the "Linked Trigger" container - it appears on both
+    // "CiviRules Add Rule" and "CiviRules Update Rule" pages,
+    // but on the "CiviRules Update Rule" it should not have vertical gaps
+    #civirule-triggerBlock-table {
+      margin-bottom: -#{$crm-standard-gap};
+      margin-top: -#{$crm-standard-gap};
+    }
   }
 
   // "CiviRules Add Condition", "CiviRules Add Action" and
@@ -81,8 +89,8 @@
 // Custom Search page and it does not contain any Rules extension specific classes
 #civirule_helptext_dialog-block + .crm-form-block {
   @include block-form();
-  padding-bottom: 0 !important;
 
+  padding-bottom: 0 !important;
   padding-top: 0 !important;
 }
 

--- a/scss/civicrm/contact/pages/_rules.scss
+++ b/scss/civicrm/contact/pages/_rules.scss
@@ -3,7 +3,8 @@
 .page-civicrm-civirule {
   // "CiviRules Add Rule" and "CiviRules Update Rule" pages
   &.page-civicrm-civirule-form-rule {
-    .crm-civirule-rule_label-block {
+    .crm-civirule-rule_label-block,
+    .crm-civirule-trigger-block {
       @include block-form();
     }
 

--- a/scss/civicrm/contact/pages/_rules.scss
+++ b/scss/civicrm/contact/pages/_rules.scss
@@ -100,6 +100,10 @@
 
   padding-bottom: 0 !important;
   padding-top: 0 !important;
+
+  + fieldset table.selector {
+    @include table-selector();
+  }
 }
 
 // Help icon in "Description" column on "Find CiviRules Rules" results page

--- a/scss/civicrm/contact/pages/_rules.scss
+++ b/scss/civicrm/contact/pages/_rules.scss
@@ -2,7 +2,7 @@
 
 .page-civicrm-civirule {
   // "CiviRules Add Rule" and "CiviRules Update Rule" pages
-  .CRM_Civirules_Form_Rule {
+  &.page-civicrm-civirule-form-rule {
     .crm-civirule-rule_label-block {
       @include block-form();
     }
@@ -44,9 +44,10 @@
     }
   }
 
-  // "CiviRules Add Condition" page
-  &.page-civicrm-civirule-form-rule-condition {
-    .crm-civirule-rule_condition-block {
+  // "CiviRules Add Condition" and "CiviRules Add Action" pages
+  &.page-civicrm-civirule-form-rule-condition,
+  &.page-civicrm-civirule-form-rule-action {
+    .crm-form-block {
       @include block-form();
     }
   }

--- a/scss/civicrm/contact/pages/_rules.scss
+++ b/scss/civicrm/contact/pages/_rules.scss
@@ -44,11 +44,21 @@
     }
   }
 
-  // "CiviRules Add Condition" and "CiviRules Add Action" pages
+  // "CiviRules Add Condition", "CiviRules Add Action" and
+  // "CiviRules Edit Action parameters" pages
   &.page-civicrm-civirule-form-rule-condition,
-  &.page-civicrm-civirule-form-rule-action {
+  &.page-civicrm-civirule-form-rule-action,
+  &.page-civicrm-civirule-form-action {
     .crm-form-block {
       @include block-form();
+    }
+  }
+
+  &.page-civicrm-civirule-form-action {
+    // There is a switch between `.groups-single` and `.groups-multiple`
+    // and `.groups-single` is not a last child, but doesn't need that margin
+    .groups-single {
+      margin-bottom: 0;
     }
   }
 

--- a/scss/civicrm/contact/pages/_rules.scss
+++ b/scss/civicrm/contact/pages/_rules.scss
@@ -2,11 +2,56 @@
 
 .page-civicrm-civirule {
 
-  // "CiviRules Add Rule" page
+  // "CiviRules Add Rule" and "CiviRules Update Rule" pages
   .CRM_Civirules_Form_Rule {
     .crm-civirule-rule_label-block,
     .crm-civirule-trigger-block {
       @include block-form();
+    }
+
+    // "CiviRules Update Rule" page
+    .crm-civirule-trigger-block,
+    .crm-civirule-rule_condition-block,
+    .crm-civirule-rule_action-block {
+      > .crm-section {
+        margin-bottom: 0;
+      }
+
+      .dataTables_wrapper {
+        box-shadow: none;
+        margin-bottom: 0;
+
+        th,
+        td {
+          border-bottom: solid 1px $gray-light;
+          color: $crm-black;
+          padding-left: $crm-standard-gap;
+          padding-right: $crm-standard-gap;
+        }
+
+        tr {
+          background-color: transparent !important;
+        }
+      }
+
+      // Table above will always have rows with bottom borders,
+      // so we remove the top border to eliminate the border duplication.
+      .crm-submit-buttons {
+        border-top: 0;
+      }
+    }
+
+    // Only one trigger can be specified, thus, flush table styling
+    #civirule-triggerBlock-table {
+      tr {
+        background-color: transparent !important;
+      }
+
+      td {
+        border-bottom: 0;
+        padding-bottom: 0;
+        padding-top: 0;
+      }
     }
   }
 }

--- a/scss/civicrm/mixins/_block-form.scss
+++ b/scss/civicrm/mixins/_block-form.scss
@@ -2,8 +2,8 @@
  * Styles block forms. Adds paddings to the form and labels.
  */
 @mixin block-form() {
-  padding-bottom: $crm-standard-gap;
-  padding-top: $crm-standard-gap;
+  padding-bottom: $crm-standard-gap !important;
+  padding-top: $crm-standard-gap !important;
 
   .label,
   .content {
@@ -12,5 +12,14 @@
 
   .content {
     padding-right: $crm-standard-gap;
+  }
+
+  .crm-section {
+    // This rule is taken from the vanilla CiviCRM
+    margin-bottom: 1em;
+
+    &:last-of-type {
+      margin-bottom: 0;
+    }
   }
 }

--- a/scss/civicrm/mixins/_block-form.scss
+++ b/scss/civicrm/mixins/_block-form.scss
@@ -9,4 +9,8 @@
   .content {
     padding-left: $crm-standard-gap;
   }
+
+  .content {
+    padding-right: $crm-standard-gap;
+  }
 }

--- a/scss/civicrm/mixins/_block-form.scss
+++ b/scss/civicrm/mixins/_block-form.scss
@@ -26,4 +26,12 @@
       margin-bottom: 0;
     }
   }
+
+  .form-layout {
+    margin-top: $crm-standard-gap;
+
+    tr td:first-of-type {
+      padding-left: $crm-standard-gap;
+    }
+  }
 }

--- a/scss/civicrm/mixins/_block-form.scss
+++ b/scss/civicrm/mixins/_block-form.scss
@@ -14,8 +14,12 @@
     padding-right: $crm-standard-gap;
   }
 
-  .crm-section {
-    // This rule is taken from the vanilla CiviCRM
+  .crm-section:last-of-type {
+    margin-bottom: 0;
+  }
+
+  .clear {
+    // This value is taken from the vanilla CiviCRM
     margin-bottom: 1em;
 
     &:last-of-type {

--- a/scss/civicrm/mixins/_block-form.scss
+++ b/scss/civicrm/mixins/_block-form.scss
@@ -1,5 +1,10 @@
 /**
- * Styles block forms. Adds paddings to the form and labels.
+ * This mixin styles a `.form-layout` div inside `.crm-accordion-body`
+ *
+ * @SEE CiviCRM -> Administer -> CiviRules -> Find Rules
+ * @NOTE this mixin may *not* be needed to be moved to global styling
+ * because it really matters what is inside an accordion body
+ * (extra content, different kind of forms, buttons etc.)
  */
 @mixin block-form() {
   padding-bottom: $crm-standard-gap !important;

--- a/scss/civicrm/mixins/_block-form.scss
+++ b/scss/civicrm/mixins/_block-form.scss
@@ -1,0 +1,12 @@
+/**
+ * Styles block forms. Adds paddings to the form and labels.
+ */
+@mixin block-form() {
+  padding-bottom: $crm-standard-gap;
+  padding-top: $crm-standard-gap;
+
+  .label,
+  .content {
+    padding-left: $crm-standard-gap;
+  }
+}

--- a/scss/civicrm/mixins/_table-selector.scss
+++ b/scss/civicrm/mixins/_table-selector.scss
@@ -1,0 +1,36 @@
+/* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type, selector-max-id */
+
+/**
+ * This mixin styles the <table> with `selector` class.
+ * This table is usually used by Civi to show results of a search.
+ *
+ * @SEE CiviCRM -> Administer -> CiviRules -> Find Rules
+ * (make sure you add a rule beforehand so it appears in the results table)
+ *
+ * @TODO Instead of having a mixin, apply the style globally to <table>.selector
+ */
+
+@mixin table-selector() {
+  background-color: $crm-white;
+
+  thead th {
+    background-color: $gray-light !important;
+  }
+
+  tbody tr:not(:last-of-type) {
+    border-bottom: solid 1px $gray-light !important;
+  }
+
+  td,
+  th {
+    border: 0 !important;
+    line-height: 1.5em !important;
+    padding-bottom: #{$crm-standard-gap / 4 * 3} !important;
+    padding-left: $crm-standard-gap !important;
+    padding-top: #{$crm-standard-gap / 4 * 3} !important;
+
+    &:last-of-type {
+      padding-right: $crm-standard-gap !important;
+    }
+  }
+}


### PR DESCRIPTION
## Overview

This PR styles CiviRules extension pages.

## Before

_Please note, this page was just used as an example_

![image](https://user-images.githubusercontent.com/3973243/53353174-12df4380-391c-11e9-9231-7e7b1840c936.png)

## After

![image](https://user-images.githubusercontent.com/3973243/53352788-5a190480-391b-11e9-9363-99a849003514.png)

## Technical Details

### Block form mixin

We need this mixin to fix the layout of block forms.

```css
@mixin block-form() {
  // otherwise, fields are attached to the borders, which is ugly
  padding-bottom: $crm-standard-gap !important;
  padding-top: $crm-standard-gap !important;

  // otherwise, fields are attached to the borders, which is ugly
  .label,
  .content {
    padding-left: $crm-standard-gap;

  .content {
    padding-right: $crm-standard-gap;

  // no last margin needed
  .crm-section:last-of-type {
    margin-bottom: 0;

  // used in each row
  .clear {
    // This value is taken from the vanilla CiviCRM
    margin-bottom: 1em;

    &:last-of-type {
      margin-bottom: 0;

  // this is for other type of tables
  .form-layout {
    margin-top: $crm-standard-gap;

    tr td:first-of-type {
      padding-left: $crm-standard-gap;
```

### Table `.selector` mixin

This mixin is needed for two reasons:
1) style the results table
2) do not produce unexpected regressions

```css
@mixin table-selector() {
  // sometimes search tables have missing <TD>s
  background-color: $crm-white;

  thead th { // in civi we have other table header styles like this
    background-color: $gray-light !important;

  tbody tr:not(:last-of-type) {
    border-bottom: solid 1px $gray-light !important;

  td,
  th {
    border: 0 !important;
    line-height: 1.5em !important; // goes from civi styling
    // why not use a formula if we have a base variable?
    padding-bottom: #{$crm-standard-gap / 4 * 3} !important;
    padding-left: $crm-standard-gap !important;
    padding-top: #{$crm-standard-gap / 4 * 3} !important;

    &:last-of-type {
      padding-right: $crm-standard-gap !important;
```


#### Before

![image](https://user-images.githubusercontent.com/3973243/53354809-859dee00-391f-11e9-8101-8c1bb48db336.png)

#### After

![image](https://user-images.githubusercontent.com/3973243/53354676-3657bd80-391f-11e9-8dd3-3b81e2e3f024.png)

### Rules Extension styles

Please note, not all code is included, only the "tricky" places:

```css
// main selector for the extension
.page-civicrm-civirule {
  &.page-civicrm-civirule-form-rule {
    // applying the mixin. Note, not everywhere we need to apply it
    .crm-civirule-rule_label-block,
    .crm-civirule-trigger-block {
      @include block-form();

      // Table above will always have rows with bottom borders,
      // so we remove the top border to eliminate the border duplication.
      .crm-submit-buttons {
        border-top: 0;

    // Fix for the "Linked Trigger" container - it appears on both
    // "CiviRules Add Rule" and "CiviRules Update Rule" pages,
    // but on the "CiviRules Update Rule" it should not have vertical gaps
    #civirule-triggerBlock-table {
      margin-bottom: -#{$crm-standard-gap};
      margin-top: -#{$crm-standard-gap};
  ...

  &.page-civicrm-civirule-form-action {
    // There is a switch between `.groups-single` and `.groups-multiple`
    // and `.groups-single` is not a last child, but doesn't need that margin
    .groups-single {
      margin-bottom: 0;
  
  ...

  // "CiviRules Add Action" page
  // we style the "time" inputs
  &.page-civicrm-civirule-form-rule-action {
    #XWeekDay_time_hour {
      text-align: right;

    #XWeekDay_time_hour,
    #XWeekDay_time_minute {
      width: 20px;
  ...
}
```

However, some selectors cannot even be isolated for extension because `page-civicrm-civirule` class does not exist on these pages.

```css
// "Find CiviRules Rules" page
// This is the only reliable selector for this page because it is built as a
// Custom Search page and it does not contain any Rules extension specific classes
#civirule_helptext_dialog-block + .crm-form-block {
  @include block-form();

  padding-bottom: 0 !important;
  padding-top: 0 !important;

// Help icon in "Description" column on "Find CiviRules Rules" results page
#civirule_help_text_icon {
  margin-left: $crm-standard-gap / 4;
```

### ⚠️New class `.crm-form-block-container`

There is a problem with form inside widely used block which looks like this:

![image](https://user-images.githubusercontent.com/3973243/53419608-1503d980-39d2-11e9-8291-1462ea28ae86.png)

As you may notice, there are no paddings (+ some other minor issues). We could apply paddings globally, but sometimes we do not need them:

![image](https://user-images.githubusercontent.com/3973243/53419761-53999400-39d2-11e9-9e51-7082b3b4ebae.png)

We could of course apply negative margins to the inner table, but not every table is needed to be like this, sometimes there are tables which are actually forms and identifying them is not an easy thing, hence the inconsistency in Civi markup.

So, to apply paddings and other fixes, we need to identify that block and apply styles. However, sometimes identifying such block are either impossible or unacceptable for Shoreditch, for example, if these blocks are a part of custom extension (we cannot identify a div by a class like `.this-is-my-cool-extension` in Shoreditch, because Shoreditch is a theme, not an extension styler).

In this particular situation, we **need** to style a 3rd party extension block. That's why we provide this class that can be applied to a container of the form and, thus, style it.

```pug
.crm-form-block-container
  h3 Some title
  .crm-form-block.crm-block
    //- some form
```

```css
.crm-form-block-container {
  .crm-form-block {
    @include block-form();
```

Once you apply it, it will look like this:

![image](https://user-images.githubusercontent.com/3973243/53420184-30231900-39d3-11e9-8b64-c8b680e6ff3d.png)

### ⚠️Global sorting icons table styling

The double-caret icon should not be offset, only single-caret icons should:

```css
a.sorting,
a.sorting_asc,
a.sorting_desc {
  ...

  &::after {
    ...
    // removed top -3px from here

  // only apply to single carets!
  &:not(.sorting) {
    &::after {
      top: 3px; 
```

## Testing

Manually tested.