### PR TITLE
SHOR-124: Style Pivot Reports extension

### DIFF
--- a/scss/civicrm/_variables.scss
+++ b/scss/civicrm/_variables.scss
@@ -1,5 +1,7 @@
 /* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type, selector-max-id */
 
+$crm-standard-gap: 20px;
+
 $contact-avatar: 90px;
 $crm-control-height: 30px;
 

--- a/scss/civicrm/contact/_contact.scss
+++ b/scss/civicrm/contact/_contact.scss
@@ -47,3 +47,4 @@ $page-class-name: str_slice($page-class, 2);
 @import 'pages/change-log';
 @import 'pages/pledges';
 @import 'pages/find-contacts';
+@import 'pages/pivot-report';

--- a/scss/civicrm/contact/pages/_pivot-report.scss
+++ b/scss/civicrm/contact/pages/_pivot-report.scss
@@ -67,6 +67,12 @@ $crm-standard-half-gap: $crm-standard-gap / 2;
       &.ui-sortable-helper {
         box-shadow: $box-shadow;
       }
+
+      &.pvtPlaceholder {
+        background-color: transparent;
+        border: dashed 1px $crm-gray-matte;
+        height: $font-size-medium + $crm-standard-gap;
+      }
     }
 
     &.pvtUnused {
@@ -104,5 +110,4 @@ $crm-standard-half-gap: $crm-standard-gap / 2;
       border: $pivot-report-border;
     }
   }
-
 }

--- a/scss/civicrm/contact/pages/_pivot-report.scss
+++ b/scss/civicrm/contact/pages/_pivot-report.scss
@@ -1,0 +1,22 @@
+/* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type, selector-max-id, scss/at-extend-no-missing-placeholder, property-no-vendor-prefix */
+
+#pivot-report-config {
+  background-color: $crm-white;
+  border-radius: $border-radius-child;
+  padding: $crm-standard-gap;
+
+  .report-config-save-new-btn {
+    // Aligns the top of the button with the top of the selector
+    margin-bottom: -14px;
+  }
+
+  // This row needs a bit of space to breathe
+  .pivot-report-output-config {
+    margin-top: #{$crm-standard-gap / 2};
+  }
+
+  .pivot-report-export-button {
+    // Makes the gap exactly 20px between buttons and bottom edge
+    margin-top: -#{$crm-standard-gap / 2};
+  }
+}

--- a/scss/civicrm/contact/pages/_pivot-report.scss
+++ b/scss/civicrm/contact/pages/_pivot-report.scss
@@ -25,12 +25,10 @@ $pivot-report-border: solid 1px $gray-light;
   margin-top: $crm-standard-gap;
   padding: #{$crm-standard-gap / 2};
 
-  .pivot-report-loading-title {
-    margin-top: #{$crm-standard-gap / 2};
-  }
-
   .progress {
+    box-shadow: none;
     margin-bottom: 0;
+    margin-top: #{$crm-standard-gap / 2};
   }
 }
 

--- a/scss/civicrm/contact/pages/_pivot-report.scss
+++ b/scss/civicrm/contact/pages/_pivot-report.scss
@@ -54,7 +54,6 @@ $crm-standard-half-gap: $crm-standard-gap / 2;
     border: 0;
   }
 
-
   .pvtAxisContainer {
     > li {
       background-color: $gray-lighter;

--- a/scss/civicrm/contact/pages/_pivot-report.scss
+++ b/scss/civicrm/contact/pages/_pivot-report.scss
@@ -8,9 +8,15 @@ $crm-standard-half-gap: $crm-standard-gap / 2;
   border-radius: $border-radius-child;
   padding: $crm-standard-half-gap;
 
-  .report-config-save-new-btn {
+  .report-config-save-new-btn,
+  .report-config-save-btn,
+  .report-config-delete-btn {
     // Aligns the top of the button with the top of the selector
     margin-bottom: -14px;
+  }
+
+  .report-config-save-btn {
+    margin-left: $crm-standard-half-gap;
   }
 
   .pivot-report-export-button {

--- a/scss/civicrm/contact/pages/_pivot-report.scss
+++ b/scss/civicrm/contact/pages/_pivot-report.scss
@@ -1,22 +1,109 @@
 /* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type, selector-max-id, scss/at-extend-no-missing-placeholder, property-no-vendor-prefix */
 
+$pivot-report-border: solid 1px $gray-light;
+
 #pivot-report-config {
   background-color: $crm-white;
   border-radius: $border-radius-child;
-  padding: $crm-standard-gap;
+  padding: #{$crm-standard-gap / 2};
 
   .report-config-save-new-btn {
     // Aligns the top of the button with the top of the selector
     margin-bottom: -14px;
   }
 
-  // This row needs a bit of space to breathe
-  .pivot-report-output-config {
-    margin-top: #{$crm-standard-gap / 2};
-  }
-
   .pivot-report-export-button {
+    margin-left: #{$crm-standard-gap / 2};
     // Makes the gap exactly 20px between buttons and bottom edge
     margin-top: -#{$crm-standard-gap / 2};
   }
+}
+
+#pivot-report-preloader {
+  background-color: $crm-white;
+  border-radius: $border-radius-child;
+  margin-top: $crm-standard-gap;
+  padding: #{$crm-standard-gap / 2};
+
+  .pivot-report-loading-title {
+    margin-top: #{$crm-standard-gap / 2};
+  }
+
+  .progress {
+    margin-bottom: 0;
+  }
+}
+
+#pivot-report-table {
+  border: 0;
+  margin-top: $crm-standard-gap;
+
+  .pvtUi {
+    border: 0;
+  }
+
+  .pvtAxisContainer,
+  .pvtVals,
+  .pvtRendererArea {
+    background-color: $crm-white;
+    border: 0;
+  }
+
+
+  .pvtAxisContainer {
+    > li {
+      background-color: $gray-lighter;
+      border: $pivot-report-border;
+      border: 0;
+      margin-bottom: $padding-base-vertical;
+
+      &:last-of-type {
+        margin-bottom: 0;
+      }
+
+      &:hover {
+        background-color: $gray-light;
+      }
+
+      &.ui-sortable-helper {
+        box-shadow: $box-shadow;
+      }
+    }
+
+    &.pvtUnused {
+      border-radius: 4px;
+    }
+
+    &.pvtRows {
+      border-radius: 0 0 0 4px;
+      border-right: $pivot-report-border;
+    }
+  }
+
+  .pvtVals {
+    border-bottom: $pivot-report-border;
+    border-radius: 4px 0 0;
+    border-right: $pivot-report-border;
+  }
+
+  .pvtHorizList {
+    border-bottom: $pivot-report-border;
+    border-radius: 0 4px 0 0;
+  }
+
+  .pvtRendererArea {
+    border-radius: 0 0 4px;
+  }
+
+  .pvtTable {
+    th {
+      background-color: $gray-lighter;
+    }
+
+    td,
+    th {
+      border: $pivot-report-border;
+    }
+  }
+
 }

--- a/scss/civicrm/contact/pages/_pivot-report.scss
+++ b/scss/civicrm/contact/pages/_pivot-report.scss
@@ -1,11 +1,12 @@
 /* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type, selector-max-id, scss/at-extend-no-missing-placeholder, property-no-vendor-prefix */
 
 $pivot-report-border: solid 1px $gray-light;
+$crm-standard-half-gap: $crm-standard-gap / 2;
 
 #pivot-report-config {
   background-color: $crm-white;
   border-radius: $border-radius-child;
-  padding: #{$crm-standard-gap / 2};
+  padding: $crm-standard-half-gap;
 
   .report-config-save-new-btn {
     // Aligns the top of the button with the top of the selector
@@ -13,9 +14,9 @@ $pivot-report-border: solid 1px $gray-light;
   }
 
   .pivot-report-export-button {
-    margin-left: #{$crm-standard-gap / 2};
+    margin-left: $crm-standard-half-gap;
     // Makes the gap exactly 20px between buttons and bottom edge
-    margin-top: -#{$crm-standard-gap / 2};
+    margin-top: -$crm-standard-half-gap;
   }
 }
 
@@ -23,12 +24,12 @@ $pivot-report-border: solid 1px $gray-light;
   background-color: $crm-white;
   border-radius: $border-radius-child;
   margin-top: $crm-standard-gap;
-  padding: #{$crm-standard-gap / 2};
+  padding: $crm-standard-half-gap;
 
   .progress {
     box-shadow: none;
     margin-bottom: 0;
-    margin-top: #{$crm-standard-gap / 2};
+    margin-top: $crm-standard-half-gap;
   }
 }
 


### PR DESCRIPTION
## Overview

This PR styles Pivot Report extension (see https://github.com/compucorp/uk.co.compucorp.civicrm.pivotreport)

## Before

![1](https://user-images.githubusercontent.com/3973243/53501218-b4dd6800-3aa3-11e9-9ef1-81dc48fdad99.gif)

## After

![2](https://user-images.githubusercontent.com/3973243/53501261-bf97fd00-3aa3-11e9-95c2-185fc6fa146c.gif)

## Technical Details

A separate page partial was created. Please note, **not all the code** is presented in the snippet below.

```css
// we use this border a lot in this file, so a var was created
$pivot-report-border: solid 1px $gray-light;
// same as above
$crm-standard-half-gap: $crm-standard-gap / 2;

#pivot-report-config {
  // we'd like content be on a white background
  background-color: $crm-white;
  border-radius: $border-radius-child;
  padding: $crm-standard-half-gap;

  .report-config-save-new-btn,
  .report-config-save-btn,
  .report-config-delete-btn {
    // Aligns the top of the button with the top of the selector
    margin-bottom: -14px;

  .pivot-report-export-button {
    margin-left: $crm-standard-half-gap;
    // Makes the gap exactly 20px between buttons and bottom edge
    margin-top: -$crm-standard-half-gap;

#pivot-report-preloader {
  ...

  .progress {
    box-shadow: none;
    margin-bottom: 0;
    margin-top: $crm-standard-half-gap;

#pivot-report-table {
  border: 0;
  margin-top: $crm-standard-gap;

  .pvtUi {
    border: 0;

  .pvtAxisContainer,
  .pvtVals,
  .pvtRendererArea {
    background-color: $crm-white;
    border: 0;

  .pvtAxisContainer {
    > li {
      background-color: $gray-lighter;
      border: $pivot-report-border;
      border: 0;
      margin-bottom: $padding-base-vertical;

      &:last-of-type {
        margin-bottom: 0;

      // hovering is very important, this tells you that the elem is interactive
      &:hover {
        background-color: $gray-light;

      // to feel the depth while dragging
      &.ui-sortable-helper {
        box-shadow: $box-shadow;

      &.pvtPlaceholder {
        background-color: transparent;
        // dashed because it is a placeholder for a drop
        border: dashed 1px $crm-gray-matte;
        // has the same height as 1 text-line elem, so no UI jumping
        height: $font-size-medium + $crm-standard-gap;

    &.pvtRows {
      // this is a TD so we need to explicitly say where the rounding is
      border-radius: 0 0 0 4px;
      // also add a border so it is separated from other TD
      border-right: $pivot-report-border;

```

## Testing

The styling is isolated to specific IDs and classes, so only manual tests were performed.