### PR TITLE
SHOR-133: Fix styles for tables, forms and modals

### DIFF
--- a/scss/civicrm/_variables.scss
+++ b/scss/civicrm/_variables.scss
@@ -1,6 +1,7 @@
 /* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type, selector-max-id */
 
 $crm-standard-gap: 20px;
+$crm-table-form-cell-padding: 4px;
 
 $contact-avatar: 90px;
 $crm-control-height: 30px;

--- a/scss/civicrm/common/_modals.scss
+++ b/scss/civicrm/common/_modals.scss
@@ -105,10 +105,6 @@
     td.label {
       padding-left: $crm-standard-gap;
     }
-
-    .form-layout-compressed {
-      margin-top: $crm-standard-gap;
-    }
   }
 
   .dataTables_length {

--- a/scss/civicrm/common/_modals.scss
+++ b/scss/civicrm/common/_modals.scss
@@ -121,6 +121,12 @@
     padding-left: $crm-standard-gap;
   }
 
+  // If the pager is the very first element in the modal, no top padding is needed
+  > .crm-form-block:first-child > .dataTables_wrapper:first-child >
+  .dataTables_length:first-child {
+    padding-top: 0;
+  }
+
   .crm-accordion-body {
     .dataTables_wrapper:first-child {
       .dataTables_length {

--- a/scss/civicrm/common/_modals.scss
+++ b/scss/civicrm/common/_modals.scss
@@ -94,10 +94,6 @@
     width: calc(100% + #{$crm-standard-gap * 2});
   }
 
-  .crm-form-block {
-    margin-bottom: 0;
-  }
-
   .crm-accordion-header:not(.crm-master-accordion-header)+.crm-accordion-body {
     box-shadow: none;
     padding: 20px 0 !important;

--- a/scss/civicrm/common/_modals.scss
+++ b/scss/civicrm/common/_modals.scss
@@ -115,6 +115,12 @@
     padding: $crm-standard-gap;
   }
 
+  // Resets the padding for entries amount selectors inside pagers
+  .crm-datatable-pager-top .dataTables_length {
+    padding: 0;
+    padding-left: $crm-standard-gap;
+  }
+
   .crm-accordion-body {
     .dataTables_wrapper:first-child {
       .dataTables_length {

--- a/scss/civicrm/common/_modals.scss
+++ b/scss/civicrm/common/_modals.scss
@@ -25,11 +25,20 @@
   }
 
   table {
-    // @NOTE This selector is used for nested accordions
+    // @NOTE This selector is used for nested accordions.
+    // Unfortunately, this seems like the only way to determine it.
     &.form-layout,
     &.form-layout-compressed {
       > tbody > tr > td[colspan='2'] {
         padding: 0;
+      }
+
+      // @NOTE This discards the padding flushing for nested tables
+      .form-layout,
+      .form-layout-compressed {
+        td[colspan='2'] {
+          padding: $crm-table-form-cell-padding;
+        }
       }
     }
 

--- a/scss/civicrm/contact/pages/_events.scss
+++ b/scss/civicrm/contact/pages/_events.scss
@@ -251,12 +251,6 @@
     width: 100%;
   }
 
-  .crm-event-eventfees-form-block-payment_information fieldset,
-  #payment_information fieldset,
-  .crm-event-form-fee-block + fieldset {
-    margin: 0 -#{$crm-standard-gap};
-  }
-
   .crm-event-eventfees-form-block-contribution_status_id,
   .crm-participant-form-block-note {
     td {

--- a/scss/civicrm/contact/pages/_events.scss
+++ b/scss/civicrm/contact/pages/_events.scss
@@ -271,6 +271,10 @@
 
 #{civi-dialog()} {
   #Participant {
+    .view-content {
+      margin: 0 -#{$crm-standard-gap};
+    }
+
     .td {
       line-height: 18px !important;
     }
@@ -283,6 +287,10 @@
 
 
 #ParticipantView {
+  .crm-contact-contribute-contributions {
+    margin: 0 -#{$crm-standard-gap};
+  }
+
   .description {
     padding: 20px;
   }

--- a/scss/civicrm/contact/pages/_new-activity.scss
+++ b/scss/civicrm/contact/pages/_new-activity.scss
@@ -119,6 +119,14 @@
     }
   }
 
+  .crm-activity-form-block-attachment,
+  .crm-activity-form-block-recurring_activity,
+  .crm-activity-form-block-schedule_followup {
+    > td {
+      padding: 0;
+    }
+  }
+
   #recurring-entity-block,
   #follow-up {
     .crm-accordion-body {


### PR DESCRIPTION
## Overview

This PR fixes regressions produced by https://github.com/civicrm/org.civicrm.shoreditch/pull/363.

## Changes

### No more paddings around accordion headers

![image](https://user-images.githubusercontent.com/3973243/54758036-55c2cd00-4be3-11e9-90d0-7987e0d681dd.png)

### Paddings after forms are back

![image](https://user-images.githubusercontent.com/3973243/54758077-670bd980-4be3-11e9-9faf-536dd278460e.png)

### No more extra paddings before forms

![image](https://user-images.githubusercontent.com/3973243/54758120-7b4fd680-4be3-11e9-8f1c-3fd1488c20df.png)

### Nicely aligned checkboxes (any form elements)

![image](https://user-images.githubusercontent.com/3973243/54758186-9c182c00-4be3-11e9-918a-40f9e5a5ded1.png)

### Aligned form fields

![image](https://user-images.githubusercontent.com/3973243/54758875-f2399f00-4be4-11e9-8776-8a2fa2beb99e.png)

### Reverting paddings on the bottom of modals

![image](https://user-images.githubusercontent.com/3973243/54759229-90c60000-4be5-11e9-8097-7c1242570d0a.png)

## Drawbacks

One solution has fixed the gaps in the modals after `.crm-block` but this cause regressions in other places, once reverted, the gap appeared again (after 100$ row):

![image](https://user-images.githubusercontent.com/3973243/54759377-dedb0380-4be5-11e9-967b-ee9a2ca47576.png)

### Fixed View/Edit Event Registration modals

![image](https://user-images.githubusercontent.com/3973243/54767626-772cb480-4bf5-11e9-9811-61e857a9fc34.png)

![image](https://user-images.githubusercontent.com/3973243/54767639-7d229580-4bf5-11e9-97fe-2cdec12deb0d.png)

![image](https://user-images.githubusercontent.com/3973243/54767671-8f9ccf00-4bf5-11e9-938d-bdf833dac4ed.png)

![image](https://user-images.githubusercontent.com/3973243/54767723-b2c77e80-4bf5-11e9-99f6-81f9101a2a70.png)

## Technical Details

### Reverting paddings where they are actually needed

`[colspan='2']` is the only way to detect accordions. However, this selector is also used inside accordions, because it is pretty general, so we need to discard the styling to the original state.

```css
.ui-dialog-content {
  table {
    &.form-layout,
    &.form-layout-compressed {
      > tbody > tr > td[colspan='2'] {
        padding: 0;

      // discarding nested
      .form-layout,
      .form-layout-compressed {
        td[colspan='2'] {
          padding: $crm-table-form-cell-padding;
```

### Removing styles that caused regressions

Note: everything listed here was added in https://github.com/civicrm/org.civicrm.shoreditch/pull/363

```css
.crm-form-block {
  margin-bottom: 0;

.form-layout-compressed {
  margin-top: $crm-standard-gap;
```

### Removing "per-page" styles

Good news, we don't need this adhoc anymore:

```css
.crm-event-eventfees-form-block-payment_information fieldset,
#payment_information fieldset,
.crm-event-form-fee-block + fieldset {
  margin: 0 -#{$crm-standard-gap};
```
as it is covered by a new global style.

### Some global specific styles

```css
// Resets the padding for entries amount selectors inside pagers
.crm-datatable-pager-top .dataTables_length {
  padding: 0;
  padding-left: $crm-standard-gap;

// If the pager is the very first element in the modal, no top padding is needed
> .crm-form-block:first-child > .dataTables_wrapper:first-child >
.dataTables_length:first-child {
  padding-top: 0;
```

These styles are needed to fix specific cases.

### Putting back the adhoc

```css
.crm-activity-form-block-attachment,
  .crm-activity-form-block-recurring_activity,
  .crm-activity-form-block-schedule_followup {
    > td {
      padding: 0;
```
this makes accordions (not in the modal) not have paddings again. This code was taken from https://github.com/civicrm/org.civicrm.shoreditch/pull/363/files#diff-cba1f4ab8ef27ddb2acab0f0e81913bbL122

### View/Edit Event Registration modals

The reason of this regression is due to custom markup and removing adhocs here:

https://github.com/civicrm/org.civicrm.shoreditch/pull/363/files#diff-46dac0d70139fffc137125fed8ea87a2L280

```css
// revert as-is
.view-content {
  margin: 0 -#{$crm-standard-gap};
```

https://github.com/civicrm/org.civicrm.shoreditch/pull/363/files#diff-46dac0d70139fffc137125fed8ea87a2L301

```css
// (!) reverting the style for the table only, the form is ALREADY styled by global styling
.crm-contact-contribute-contributions {
  margin: 0 -#{$crm-standard-gap};
```

## Tests

Each commit has been accompanied with BackstopJS tests.
