### PR TITLE
SHOR-135: Fix position of quicksearch results

### DIFF
--- a/scss/civicrm/main-menu/_main-menu.scss
+++ b/scss/civicrm/main-menu/_main-menu.scss
@@ -141,6 +141,7 @@
   font-family: $font-family-base;
   left: 0 !important;
   padding: $crm-main-menu-sub-menu-padding;
+  position: fixed;
   top: $crm-main-menu-height !important;
 
   .ui-menu-item {


### PR DESCRIPTION
Closes #341 

## Before
![search-before](https://user-images.githubusercontent.com/6400898/55338925-fcd81c00-54a1-11e9-98df-983548e660f7.gif)

## After
![search-after](https://user-images.githubusercontent.com/6400898/55338924-fc3f8580-54a1-11e9-8dbc-600be8f2bcb1.gif)


## Technical details
This PR is a subset of #359, I've kept only the one change that was strictly about the search results being always visible
