### PR TITLE
Update _ui-select.scss

### DIFF
--- a/scss/bootstrap/overrides/crm/outside-namespace/_ui-select.scss
+++ b/scss/bootstrap/overrides/crm/outside-namespace/_ui-select.scss
@@ -9,5 +9,5 @@
 }
 
 .ui-widget-overlay.ui-front {
-  z-index: 2000;
+  z-index: 99;
 }


### PR DESCRIPTION
The current value blocks the user interface for adding fields, etc in Drupal Views. Setting z-index: 99 does not block it.