### PR TITLE
SHOR-143: Style Mailing screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Please note that this extension is currrently in **alpha stage** and under **act
 
 ## Requirements
 * Drupal 7
-* CiviCRM `v5.8`+, `v5.12`+ recommended
+* CiviCRM `v5.16`+. In version `v5.16.0` CiviCRM introduces Theming (https://docs.civicrm.org/dev/en/latest/framework/theme) which makes Shoreditch no longer support the obsolete way of theme inclusion (since Shoreditch `v0.1-alpha34`) and drop the support for earlier CiviCRM versions.
 * [uk.squiffle.kam](https://github.com/aydun/uk.squiffle.kam) if the CiviCRM version is lower than `v5.12`
 * "CiviCRM Theme" module enabled
 * The [CiviAdmin Companion Drupal theme](https://github.com/compucorp/shoreditch-companion-d7-theme) is optional but recommended (only for Shoreditch `v0.1-alpha33`+)

--- a/scss/civicrm/_variables.scss
+++ b/scss/civicrm/_variables.scss
@@ -2,7 +2,7 @@
 
 $crm-standard-gap: 20px;
 $crm-table-form-cell-padding: 4px;
-$crm-box-radius: 2px;
+$crm-block-border-radius: 2px;
 
 $contact-avatar: 90px;
 $crm-control-height: 30px;

--- a/scss/civicrm/contact/pages/_pivot-report.scss
+++ b/scss/civicrm/contact/pages/_pivot-report.scss
@@ -2,7 +2,7 @@
 
 $pivot-report-border: solid 1px $gray-light;
 $crm-standard-half-gap: $crm-standard-gap / 2;
-$pivot-report-box-radius: $crm-box-radius * 2;
+$pivot-report-box-radius: $crm-block-border-radius * 2;
 
 #pivot-report-config {
   background-color: $crm-white;

--- a/scss/civicrm/contact/pages/_rules.scss
+++ b/scss/civicrm/contact/pages/_rules.scss
@@ -25,7 +25,7 @@
     position: relative;
 
     &::before {
-      border-radius: $crm-box-radius;
+      border-radius: $crm-block-border-radius;
       bottom: 0;
       box-shadow: $box-shadow;
       content: '';
@@ -38,7 +38,7 @@
   }
 
   .crm-container .crm-form-block {
-    border-radius: 0 0 #{$crm-box-radius} #{$crm-box-radius} !important;
+    border-radius: 0 0 #{$crm-block-border-radius} #{$crm-block-border-radius} !important;
 
     .crm-submit-buttons {
       background-color: transparent !important;

--- a/scss/civicrm/custom-civicrm.scss
+++ b/scss/civicrm/custom-civicrm.scss
@@ -26,3 +26,4 @@
 @import 'civicrm/grant/grant';
 @import 'civicrm/pledge/pledge';
 @import 'civicrm/discount/discount';
+@import 'civicrm/mailing/mailing';

--- a/scss/civicrm/mailing/_mailing.scss
+++ b/scss/civicrm/mailing/_mailing.scss
@@ -1,1 +1,2 @@
-@import 'pages/mailing-all';
+@import 'pages/mailing-search';
+@import 'pages/mailing-report';

--- a/scss/civicrm/mailing/_mailing.scss
+++ b/scss/civicrm/mailing/_mailing.scss
@@ -1,0 +1,1 @@
+@import 'pages/mailing-all';

--- a/scss/civicrm/mailing/pages/_mailing-all.scss
+++ b/scss/civicrm/mailing/pages/_mailing-all.scss
@@ -1,0 +1,107 @@
+/* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type, selector-max-id */
+
+#{civi-page('mailing')} {
+  $crm-table-cell-vertical-padding: 12px;
+  $crm-block-border-radius: 2px;
+  $crm-alpha-filter-padding: 2px;
+
+  // Makes the wrapper look like a container
+  #crm-main-content-wrapper {
+    background-color: $crm-white !important;
+    border-radius: $crm-block-border-radius;
+    box-shadow: $box-shadow;
+    padding: $crm-standard-gap;
+  }
+
+  // Just needs to breathe and not look like a part of form
+  .action-link {
+    margin-bottom: $crm-standard-gap;
+  }
+
+  // Second CTA button is no necessary
+  script + .action-link {
+    display: none;
+  }
+
+  // Left padding misalighes the form with the rest of elements
+  table.form-layout {
+    td:first-child {
+      padding-left: 0;
+    }
+  }
+
+  // Stretches the A-Z filter to full width and dismisses its default colour
+  #alpha-filter {
+    background-color: transparent !important;
+    width: calc(100% + #{($crm-standard-gap - $crm-alpha-filter-padding) * 2});
+  }
+
+  // Removes unwanted shadows
+  table.row-highlight,
+  .crm-pager,
+  .crm-search-form-block {
+    box-shadow: none !important;
+  }
+
+  // Attaches the A-Z filter and tables to the left
+  #alpha-filter,
+  table.row-highlight {
+    margin-left: -#{$crm-standard-gap} !important;
+  }
+
+  .crm-pager {
+    // Attaches pager to the right
+    .element-right {
+      margin-right: 0 !important;
+    }
+
+    .crm-pager-nav {
+      // Discards three &nbsp; at the start
+      a[title='next page'] {
+        left: -#{$crm-standard-gap} !important;
+      }
+
+      // Attaches pages navigation to the left by
+      // discarding padding for first navigation element
+      a:first-child {
+        padding-left: 0;
+      }
+    }
+  }
+
+  table.row-highlight {
+    // Stretches the table to full width
+    width: calc(100% + #{$crm-standard-gap * 2});
+
+    thead > tr {
+      border: solid 1px $crm-grayblue-dark !important;
+      border-left: 0 !important;
+      border-right: 0 !important;
+    }
+
+    th {
+      background-color: $gray-lighter !important;
+      border: 0 !important;
+      padding-bottom: $crm-standard-gap !important;
+      padding-top: $crm-standard-gap !important;
+    }
+
+    td {
+      padding-bottom: $crm-table-cell-vertical-padding;
+      padding-top: $crm-table-cell-vertical-padding;
+    }
+
+    td,
+    th {
+      line-height: 1.5em !important;
+
+      &:first-child {
+        padding-left: $crm-standard-gap;
+      }
+
+      &:last-child {
+        padding-right: $crm-standard-gap;
+      }
+    }
+  }
+}

--- a/scss/civicrm/mailing/pages/_mailing-report.scss
+++ b/scss/civicrm/mailing/pages/_mailing-report.scss
@@ -1,0 +1,51 @@
+/* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type, selector-max-id */
+
+#{civi-page('mailing-report')} {
+  fieldset {
+    background-color: $crm-white !important;
+    border-radius: $crm-block-border-radius;
+    box-shadow: $box-shadow;
+    margin-bottom: $crm-standard-gap;
+    padding: $crm-standard-gap;
+    padding-bottom: 0;
+
+    legend {
+      background-color: $gray-lighter !important;
+      border-bottom: 1px solid $crm-grayblue-dark !important;
+      border-radius: $crm-block-border-radius $crm-block-border-radius 0 0;
+      color: $gray-darker !important;
+      float: left;
+      font-size: $font-size-h2 !important;
+      line-height: 28px !important;
+      margin-bottom: 0;
+      margin-left: -#{$crm-standard-gap} !important;
+      margin-top: -#{$crm-standard-gap} !important;
+      padding: $ui-modal-header-padding !important;
+      width: 100% !important;
+    }
+
+    > span.label {
+      display: block;
+      margin: #{$crm-standard-gap / 4} 0;
+    }
+  }
+
+  table.crm-info-panel {
+    @include table-selector();
+
+    border: 0 !important;
+    border-radius: $crm-block-border-radius;
+    margin-left: -#{$crm-standard-gap} !important;
+    width: calc(100% + #{$crm-standard-gap * 2});
+
+    td,
+    th {
+      background-color: transparent !important;
+    }
+
+    td.label {
+      color: $crm-black !important;
+      font-size: $font-size-base;
+    }
+  }
+}

--- a/scss/civicrm/mailing/pages/_mailing-report.scss
+++ b/scss/civicrm/mailing/pages/_mailing-report.scss
@@ -26,7 +26,15 @@
 
     > span.label {
       display: block;
-      margin: #{$crm-standard-gap / 4} 0;
+      margin: #{$crm-standard-gap * 2} 0 #{$crm-standard-gap / 4} 0;
+    }
+
+    > * {
+      clear: both;
+    }
+
+    > .messages {
+      margin-top: $crm-standard-gap * 2;
     }
   }
 

--- a/scss/civicrm/mailing/pages/_mailing-report.scss
+++ b/scss/civicrm/mailing/pages/_mailing-report.scss
@@ -26,7 +26,8 @@
 
     > span.label {
       display: block;
-      margin: #{$crm-standard-gap * 2} 0 #{$crm-standard-gap / 4} 0;
+      margin-top: $crm-standard-gap * 2;
+      padding-top: $crm-main-menu-padding-small;
     }
 
     > * {
@@ -55,5 +56,10 @@
       color: $crm-black !important;
       font-size: $font-size-base;
     }
+  }
+
+  // We do not need striped tables here
+  .odd-row {
+    background-color: $crm-white !important;
   }
 }

--- a/scss/civicrm/mailing/pages/_mailing-search.scss
+++ b/scss/civicrm/mailing/pages/_mailing-search.scss
@@ -1,8 +1,7 @@
 /* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type, selector-max-id */
 
-#{civi-page('mailing')} {
+#{civi-page('mailing-browse')} {
   $crm-table-cell-vertical-padding: 12px;
-  $crm-block-border-radius: 2px;
   $crm-alpha-filter-padding: 2px;
 
   // Makes the wrapper look like a container
@@ -30,12 +29,6 @@
     }
   }
 
-  // Stretches the A-Z filter to full width and dismisses its default colour
-  #alpha-filter {
-    background-color: transparent !important;
-    width: calc(100% + #{($crm-standard-gap - $crm-alpha-filter-padding) * 2});
-  }
-
   // Removes unwanted shadows
   table.row-highlight,
   .crm-pager,
@@ -43,10 +36,12 @@
     box-shadow: none !important;
   }
 
-  // Attaches the A-Z filter and tables to the left
-  #alpha-filter,
-  table.row-highlight {
-    margin-left: -#{$crm-standard-gap} !important;
+  // Attaches the A-Z filter to the left,
+  // stretches it to the full width and dismisses its default colour
+  #alpha-filter {
+    background-color: transparent !important;
+    margin-left: -#{$crm-standard-gap / 2} !important;
+    width: calc(100% + #{($crm-standard-gap / 2 - $crm-alpha-filter-padding) * 2});
   }
 
   .crm-pager {
@@ -70,6 +65,8 @@
   }
 
   table.row-highlight {
+    // Attaches tables to the left
+    margin-left: -#{$crm-standard-gap} !important;
     // Stretches the table to full width
     width: calc(100% + #{$crm-standard-gap * 2});
 


### PR DESCRIPTION
# Overview

This PR styles the following screens in CiviCRM:
- Mailing Browse / Search - `/civicrm/mailing/browse/unscheduled?reset=1&scheduled=false`
- Mailing Reports - `/civicrm/mailing/report?mid=5&reset=1`

# Before

## Mailing Browse / Search

![Before 1](https://user-images.githubusercontent.com/3973243/62631242-4f31b980-b928-11e9-9cfe-0ea7022fa04f.png)

## Mailing Reports

![Before 2](https://user-images.githubusercontent.com/3973243/62631227-4b059c00-b928-11e9-8bb5-50e9c7374bd5.png)

# After

## Mailing Browse / Search

![After 1](https://user-images.githubusercontent.com/3973243/62631212-45a85180-b928-11e9-93e4-0d244ea4b91d.png)

## Mailing Reports

![After 2](https://user-images.githubusercontent.com/3973243/62631204-3f19da00-b928-11e9-941d-decc1714638d.png)

# Technical Details

We did not amend any core markup to avoid unexpected changes in CiviCRM UI without Shoreditch. Instead, we applied **isolated** per-page CSS styles. The styles are trivial in most places but there is one specific to note explicitly:

```
#{civi-page('mailing-report')} {
  fieldset {
    legend {
      ... 
      // Otherwise it will actually be "detached" from the fieldset
      float: left;
```

## Why so many !importants?

The reason is that we can either same selectors as Civi or `!important`. In that particular case, when we are styling a page, `!important` has more sense because the code looks cleaner and we will not need to override these styles again, they are not global. Additionally, some styles coming from Civi actually have `!important` already.

# Tests

Manual. BackstopJS was **not** run because we have isolated the pages via CSS selectors.