### PR TITLE
SHOR-141: Fix misc issues with CiviCRM and Shoreditch UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.DS_Store

--- a/scss/civicrm/_variables.scss
+++ b/scss/civicrm/_variables.scss
@@ -2,7 +2,6 @@
 
 $crm-standard-gap: 20px;
 $crm-table-form-cell-padding: 4px;
-$crm-block-border-radius: 2px;
 
 $contact-avatar: 90px;
 $crm-control-height: 30px;

--- a/scss/civicrm/_variables.scss
+++ b/scss/civicrm/_variables.scss
@@ -15,6 +15,7 @@ $crm-form-item-shadow: 0 3px 6px 0 rgba(48, 40, 40, 0.25);
 $crm-form-layout-shadow: 0 3px 18px 0 rgba(48, 40, 40, 0.25);
 $crm-form-layout-shadow-lower: 0 8px 18px 0 rgba(48, 40, 40, 0.25);
 $crm-input-shadow: 0 0 3px 0 rgba(0, 0, 0, 0.2) inset;
+$crm-input-padding: 2px 10px;
 $crm-search-input-shadow: 0 1px 1px rgba(0, 0, 0, 0.075) inset;
 $crm-tab-shadow: 0 9px 9px 0 rgba(48, 40, 40, 0.25);
 $crm-box-shadow-inset-top: inset 0 10px 8px -10px rgba(0, 0, 0, 0.15);

--- a/scss/civicrm/administer/_administer.scss
+++ b/scss/civicrm/administer/_administer.scss
@@ -39,6 +39,8 @@
   @import 'member/membershipstatus';
   @import 'member/preferences';
 
+  @import 'report/report';
+
   @import 'settings/components';
   @import 'settings/extensions';
   @import 'settings/scheduled-jobs';

--- a/scss/civicrm/administer/report/_report.scss
+++ b/scss/civicrm/administer/report/_report.scss
@@ -1,0 +1,25 @@
+/* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type, selector-max-id */
+
+/**
+ * Fixes action buttons that are placed inside <TD>
+ * which makes them appear on two lines instead of just one.
+ *
+ * @SEE /civicrm/admin/report/register
+ */
+.crm-report-register-form-block tbody {
+  &,
+  > .crm-report-register-form-block-buttons {
+    &,
+    > td {
+      display: block;
+    }
+  }
+
+  > .crm-report-register-form-block-buttons:first-of-type {
+
+    .crm-submit-buttons {
+      padding-top: 0;
+      border-top: 0 !important;
+    }
+  }
+}

--- a/scss/civicrm/cases/_cases.scss
+++ b/scss/civicrm/cases/_cases.scss
@@ -2,3 +2,4 @@
 
 @import 'dashboard';
 @import 'manage';
+@import 'search';

--- a/scss/civicrm/cases/_search.scss
+++ b/scss/civicrm/cases/_search.scss
@@ -2,73 +2,74 @@
 
 #{civi-page('case-search')} {
   .crm-accordion-body .form-layout {
+    display: block;
     margin-top: $crm-standard-gap;
 
-    &,
-    tbody,
-    tr,
-    td {
+    > tbody:first-child {
       display: block;
-    }
 
-    tbody:first-child > tr {
-      td {
-        margin-left: $crm-standard-gap;
+      > tr {
+        display: block;
 
-        // Display labels as blocks for margins and paddings consistency
-        > label:first-child {
-          display: block;
-
-          // Remove <br>s after labels because labels are displayed as blocks
-          & + br {
-            display: none;
-          }
-        }
-      }
-
-      &:nth-of-type(1) {
         > td {
-          // Brings "Client Name or Email" and the input to individual lines
-          &:nth-of-type(1) {
-            label {
-              display: block;
+          display: block;
+          margin-left: $crm-standard-gap;
 
-              & + input {
-                margin-left: -0.6em;
-              }
+          // Display labels as blocks for margins and paddings consistency
+          > label:first-child {
+            display: block;
+
+            // Remove <br>s after labels because labels are displayed as blocks
+            + br {
+              display: none;
             }
           }
+        }
 
-          // Remove duplicate Search button
-          &:nth-of-type(2) {
-            display: none !important;
+        &:nth-of-type(1) {
+          > td {
+            // Brings "Client Name or Email" and the input to individual lines
+            &:nth-of-type(1) {
+              label {
+                display: block;
+
+                + input {
+                  margin-left: -0.6em;
+                }
+              }
+            }
+
+            // Remove duplicate Search button
+            &:nth-of-type(2) {
+              display: none !important;
+            }
           }
         }
-      }
 
-      // Discard paddings between dates labels and inputs
-      &:nth-of-type(3),
-      &:nth-of-type(4) {
-        > td {
-          &:first-child {
-            padding-bottom: 0;
-          }
+        // Discard paddings between dates labels and inputs
+        &:nth-of-type(3),
+        &:nth-of-type(4) {
+          > td {
+            &:first-child {
+              padding-bottom: 0;
+            }
 
-          &:last-child {
-            padding-top: 0;
+            &:last-child {
+              padding-top: 0;
+            }
           }
         }
-      }
 
-      // Adds a gap between "Case Status" and "Search All Cases / Only My Cases"
-      #s2id_case_status_id {
-        margin-bottom: $crm-standard-gap;
-      }
+        // Adds a gap between "Case Status" and "Search All Cases / Only My Cases"
+        #s2id_case_status_id {
+          margin-bottom: $crm-standard-gap;
+        }
 
-      // Adds a gap between "Search All Cases / Only My Cases" and "Delete Cases"
-      label[for="case_deleted"] {
-        display: inline-block;
-        margin-top: $crm-standard-gap / 2;
+        // Adds a gap between "Search All Cases / Only My Cases" and "Delete Cases"
+        label[for='case_deleted'] {
+          display: inline-block;
+          margin-top: $crm-standard-gap / 2;
+        }
       }
     }
   }

--- a/scss/civicrm/cases/_search.scss
+++ b/scss/civicrm/cases/_search.scss
@@ -43,6 +43,7 @@
                 display: block;
 
                 + input {
+                  // Discard two hardcoded &nbsp; characters in CiviCRM
                   margin-left: -0.6em;
                 }
               }

--- a/scss/civicrm/cases/_search.scss
+++ b/scss/civicrm/cases/_search.scss
@@ -1,0 +1,75 @@
+/* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type, selector-max-id */
+
+#{civi-page('case-search')} {
+  .crm-accordion-body .form-layout {
+    margin-top: $crm-standard-gap;
+
+    &,
+    tbody,
+    tr,
+    td {
+      display: block;
+    }
+
+    tbody:first-child > tr {
+      td {
+        margin-left: $crm-standard-gap;
+
+        // Display labels as blocks for margins and paddings consistency
+        > label:first-child {
+          display: block;
+
+          // Remove <br>s after labels because labels are displayed as blocks
+          & + br {
+            display: none;
+          }
+        }
+      }
+
+      &:nth-of-type(1) {
+        > td {
+          // Brings "Client Name or Email" and the input to individual lines
+          &:nth-of-type(1) {
+            label {
+              display: block;
+
+              & + input {
+                margin-left: -0.6em;
+              }
+            }
+          }
+
+          // Remove duplicate Search button
+          &:nth-of-type(2) {
+            display: none !important;
+          }
+        }
+      }
+
+      // Discard paddings between dates labels and inputs
+      &:nth-of-type(3),
+      &:nth-of-type(4) {
+        > td {
+          &:first-child {
+            padding-bottom: 0;
+          }
+
+          &:last-child {
+            padding-top: 0;
+          }
+        }
+      }
+
+      // Adds a gap between "Case Status" and "Search All Cases / Only My Cases"
+      #s2id_case_status_id {
+        margin-bottom: $crm-standard-gap;
+      }
+
+      // Adds a gap between "Search All Cases / Only My Cases" and "Delete Cases"
+      label[for="case_deleted"] {
+        display: inline-block;
+        margin-top: $crm-standard-gap / 2;
+      }
+    }
+  }
+}

--- a/scss/civicrm/cases/_search.scss
+++ b/scss/civicrm/cases/_search.scss
@@ -24,6 +24,15 @@
               display: none;
             }
           }
+
+          > .crm-accordion-wrapper {
+            margin-left: -#{$crm-standard-gap + $crm-table-form-cell-padding};
+            margin-right: -#{$crm-table-form-cell-padding};
+
+            .crm-accordion-body {
+              box-shadow: none;
+            }
+          }
         }
 
         &:nth-of-type(1) {

--- a/scss/civicrm/common/_block-shadows.scss
+++ b/scss/civicrm/common/_block-shadows.scss
@@ -15,22 +15,26 @@
   z-index: 0;
 }
 
-h3:not(.crm-severity-info),
-h3:not(.crm-severity-info) + .crm-block {
-  // Discard direct shadows
-  box-shadow: none !important;
-  position: relative;
+*:not(.crm-form-block) {
+  > h3:not(.crm-severity-info) {
+    &,
+    + .crm-block {
+      // Discard direct shadows
+      box-shadow: none !important;
+      position: relative;
 
-  &::before {
-    bottom: 0;
-    box-shadow: $box-shadow;
-    content: '';
-    left: 0;
-    position: absolute;
-    right: 0;
-    top: 0;
-    // This is needed to place the shadows underneath so they do not overlap
-    z-index: -1;
+      &::before {
+        bottom: 0;
+        box-shadow: $box-shadow;
+        content: '';
+        left: 0;
+        position: absolute;
+        right: 0;
+        top: 0;
+        // This is needed to place the shadows underneath so they do not overlap
+        z-index: -1;
+      }
+    }
   }
 }
 

--- a/scss/civicrm/common/_block-shadows.scss
+++ b/scss/civicrm/common/_block-shadows.scss
@@ -39,13 +39,13 @@
 }
 
 h3::before {
-  border-radius: #{$crm-block-border-radius} #{$crm-block-border-radius} 0 0 !important;
+  border-radius: #{$border-radius-base} #{$border-radius-base} 0 0 !important;
 }
 
 h3 + .crm-form-block {
   &,
   &::before {
-    border-radius: 0 0 #{$crm-block-border-radius} #{$crm-block-border-radius} !important;
+    border-radius: 0 0 #{$border-radius-base} #{$border-radius-base} !important;
   }
 
   .crm-submit-buttons {

--- a/scss/civicrm/common/_block-shadows.scss
+++ b/scss/civicrm/common/_block-shadows.scss
@@ -15,8 +15,8 @@
   z-index: 0;
 }
 
-h3,
-h3 + .crm-block {
+h3:not(.crm-severity-info),
+h3:not(.crm-severity-info) + .crm-block {
   // Discard direct shadows
   box-shadow: none !important;
   position: relative;

--- a/scss/civicrm/common/_block-shadows.scss
+++ b/scss/civicrm/common/_block-shadows.scss
@@ -1,0 +1,51 @@
+/* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type, selector-max-id */
+
+/**
+ * Applies proper shadows to the <h3> + <div class="crm-block"> pair.
+ *
+ * @NOTE
+ * If you apply shadows to these elements directly (not via :before pseudoclass),
+ * then the shadows will overlap. The method makes it visually look like there is
+ * just a single shadow underneath the pair.
+ */
+
+// Need that otherwise shadows will be cropped on the top and the bottom
+#crm-main-content-wrapper {
+  position: relative;
+  z-index: 0;
+}
+
+h3,
+h3 + .crm-block {
+  // Discard direct shadows
+  box-shadow: none !important;
+  position: relative;
+
+  &::before {
+    bottom: 0;
+    box-shadow: $box-shadow;
+    content: '';
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+    // This is needed to place the shadows underneath so they do not overlap
+    z-index: -1;
+  }
+}
+
+h3::before {
+  border-radius: #{$crm-block-border-radius} #{$crm-block-border-radius} 0 0 !important;
+}
+
+h3 + .crm-form-block {
+  &,
+  &::before {
+    border-radius: 0 0 #{$crm-block-border-radius} #{$crm-block-border-radius} !important;
+  }
+
+  .crm-submit-buttons {
+    // Need to discard the background otherwise this block will have sharp edges
+    background-color: transparent !important;
+  }
+}

--- a/scss/civicrm/common/_buttons.scss
+++ b/scss/civicrm/common/_buttons.scss
@@ -254,7 +254,8 @@ $button-border-radius: 2px;
     .crm-i {
       background-color: transparent !important;
       color: $crm-white;
-      padding: 3px;
+      padding: 2px 3px;
+      top: 0;
     }
   }
 

--- a/scss/civicrm/common/_common.scss
+++ b/scss/civicrm/common/_common.scss
@@ -34,3 +34,4 @@
 @import 'ui-spinner-input';
 @import 'links-list';
 @import 'main-menu';
+@import 'block-shadows';

--- a/scss/civicrm/common/_forms.scss
+++ b/scss/civicrm/common/_forms.scss
@@ -225,7 +225,7 @@ input.crm-form-password {
   font-family: $font-family-base;
   font-size: $font-size-base;
   height: $input-height-small;
-  padding: 2px 10px;
+  padding: $crm-input-padding;
 
   &:focus {
     border-color: $input-border-focus;

--- a/scss/civicrm/common/_modals.scss
+++ b/scss/civicrm/common/_modals.scss
@@ -20,9 +20,12 @@
 }
 
 .ui-dialog-content {
-  > form,
   .messages.no-popup {
     margin-bottom: $crm-standard-gap;
+  }
+
+  > form .crm-accordion-wrapper:last-of-type.collapsed > .crm-accordion-header {
+    border-bottom: 0;
   }
 
   table {

--- a/scss/civicrm/common/_modals.scss
+++ b/scss/civicrm/common/_modals.scss
@@ -20,6 +20,7 @@
 }
 
 .ui-dialog-content {
+  > form,
   .messages.no-popup {
     margin-bottom: $crm-standard-gap;
   }

--- a/scss/civicrm/contact/pages/_activities.scss
+++ b/scss/civicrm/contact/pages/_activities.scss
@@ -1,7 +1,23 @@
+/* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type, selector-max-id, scss/at-extend-no-missing-placeholder */
+
 .contact-activity-selector-activity {
   .status-overdue {
     td {
       color: $brand-danger !important;
+    }
+  }
+}
+
+.crm-activity-selector-activity .crm-absolute-date-range {
+  .crm-absolute-date-from,
+  .crm-absolute-date-to {
+    display: block;
+    margin-top: $crm-standard-gap / 2;
+
+    > label {
+      display: inline-block;
+      text-align: right;
+      width: $crm-standard-gap * 2;
     }
   }
 }

--- a/scss/civicrm/contact/pages/_batch.scss
+++ b/scss/civicrm/contact/pages/_batch.scss
@@ -93,8 +93,6 @@
 }
 
 #{civi-page('batch')} #Batch {
-  box-shadow: $box-shadow;
-
   .crm-submit-buttons {
     border: 0;
   }

--- a/scss/civicrm/contact/pages/_contact-dedupefind.scss
+++ b/scss/civicrm/contact/pages/_contact-dedupefind.scss
@@ -60,4 +60,11 @@
   #{civi-dialog()} {
     min-width: 400px;
   }
+
+  #searchOptions input[type='text'] {
+    @include input-text();
+    border: solid 1px $crm-grayblue-darker;
+    height: $input-height-small;
+    padding: $crm-input-padding;
+  }
 }

--- a/scss/civicrm/contact/pages/_find-and-merge-duplicate.scss
+++ b/scss/civicrm/contact/pages/_find-and-merge-duplicate.scss
@@ -104,8 +104,6 @@
 
 
 #DedupeRules {
-  box-shadow: $box-shadow;
-  
   .crm-dedupe-rules-form-block {
     box-shadow: none;
   }

--- a/scss/civicrm/contact/pages/_pivot-report.scss
+++ b/scss/civicrm/contact/pages/_pivot-report.scss
@@ -2,7 +2,7 @@
 
 $pivot-report-border: solid 1px $gray-light;
 $crm-standard-half-gap: $crm-standard-gap / 2;
-$pivot-report-box-radius: $crm-block-border-radius * 2;
+$pivot-report-box-radius: $border-radius-base * 2;
 
 #pivot-report-config {
   background-color: $crm-white;

--- a/scss/civicrm/contact/pages/_rules.scss
+++ b/scss/civicrm/contact/pages/_rules.scss
@@ -1,50 +1,6 @@
 /* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type, selector-max-id */
 
 .page-civicrm-civirule {
-  position: relative;
-
-  /**
-   * Apply shadows to the <h3> + .crm-block pair
-   */
-  // This is needed to make elements clickable
-  z-index: -3;
-
-  // This is needed because otherwise shadows will be cut
-  #page {
-    z-index: -2;
-  }
-
-  #crm-main-content-wrapper {
-    position: relative;
-    z-index: 0;
-  }
-
-  h3,
-  h3 + .crm-block {
-    box-shadow: none !important;
-    position: relative;
-
-    &::before {
-      border-radius: $crm-block-border-radius;
-      bottom: 0;
-      box-shadow: $box-shadow;
-      content: '';
-      left: 0;
-      position: absolute;
-      right: 0;
-      top: 0;
-      z-index: -1;
-    }
-  }
-
-  .crm-container .crm-form-block {
-    border-radius: 0 0 #{$crm-block-border-radius} #{$crm-block-border-radius} !important;
-
-    .crm-submit-buttons {
-      background-color: transparent !important;
-    }
-  }
-
   // "CiviRules Add Rule" and "CiviRules Update Rule" pages
   &.page-civicrm-civirule-form-rule {
     .crm-civirule-rule_label-block,

--- a/scss/civicrm/mailing/pages/_mailing-report.scss
+++ b/scss/civicrm/mailing/pages/_mailing-report.scss
@@ -3,7 +3,7 @@
 #{civi-page('mailing-report')} {
   fieldset {
     background-color: $crm-white !important;
-    border-radius: $crm-block-border-radius;
+    border-radius: $border-radius-base;
     box-shadow: $box-shadow;
     margin-bottom: $crm-standard-gap;
     padding: $crm-standard-gap;
@@ -12,7 +12,7 @@
     legend {
       background-color: $gray-lighter !important;
       border-bottom: 1px solid $crm-grayblue-dark !important;
-      border-radius: $crm-block-border-radius $crm-block-border-radius 0 0;
+      border-radius: $border-radius-base $border-radius-base 0 0;
       color: $gray-darker !important;
       float: left;
       font-size: $font-size-h2 !important;
@@ -43,7 +43,7 @@
     @include table-selector();
 
     border: 0 !important;
-    border-radius: $crm-block-border-radius;
+    border-radius: $border-radius-base;
     margin-left: -#{$crm-standard-gap} !important;
     width: calc(100% + #{$crm-standard-gap * 2});
 

--- a/scss/civicrm/mailing/pages/_mailing-search.scss
+++ b/scss/civicrm/mailing/pages/_mailing-search.scss
@@ -7,7 +7,7 @@
   // Makes the wrapper look like a container
   #crm-main-content-wrapper {
     background-color: $crm-white !important;
-    border-radius: $crm-block-border-radius;
+    border-radius: $border-radius-base;
     box-shadow: $box-shadow;
     padding: $crm-standard-gap;
   }

--- a/scss/jquery/overrides/_select2.scss
+++ b/scss/jquery/overrides/_select2.scss
@@ -247,5 +247,19 @@ $crm-jquery-select2-search-items-label-padding: 5px 10px;
     .select2-selection-limit {
       background: $crm-white;
     }
+
+    .Individual-icon {
+      background: none;
+      text-indent: 0;
+
+      &:before {
+        // Align with the original icon position
+        margin-left: 2px;
+        font-size: $font-size-medium;
+        display: block;
+        content: '\f007';
+        font-family: "FontAwesome";
+      }
+    }
   }
 }


### PR DESCRIPTION
# Overview

This PR fixes miscellaneous issues with CiviCRM / Shoreditch styling. Please see the "Changes" section for more information.

# Changes

| What | Before  | After | Any global styling? |
| ------------- | ------------- | ------------- | ------------- |
| Report Register header shadows and action buttons | ![image](https://user-images.githubusercontent.com/3973243/62858287-ca60ea00-bcf1-11e9-8132-4c4d93da0704.png) | ![image](https://user-images.githubusercontent.com/3973243/62868923-a233b400-bd0e-11e9-9e69-51ea72eef810.png) | Yes, shadows |
| Fix paddings, labels positioning and button icons in Case Search | ![AwesomeScreenshot-localhost--civicrm-case-search-2019-08-15_3_22](https://user-images.githubusercontent.com/3973243/63101217-79aaf480-bf70-11e9-8c53-57ae1eed4382.png) | ![AwesomeScreenshot-localhost--civicrm-case-search-2019-08-15_3_18](https://user-images.githubusercontent.com/3973243/63101027-29339700-bf70-11e9-94b2-97c5f726466c.png) | Yes, icons in buttons ![image](https://user-images.githubusercontent.com/3973243/62860146-21b58900-bcf7-11e9-8219-5aa54d9e5939.png) |
| Add a padding on the bottom of form modals | ![image](https://user-images.githubusercontent.com/3973243/62862991-6e04c700-bcff-11e9-9156-83a73337af56.png) | ![image](https://user-images.githubusercontent.com/3973243/62863081-b328f900-bcff-11e9-9129-44afffad1afe.png) | Yes, applied globally to all modals |
| Improve styling of date filters in Contact Activity | ![image](https://user-images.githubusercontent.com/3973243/62870871-4834ed80-bd12-11e9-98fa-9526e1f4b8c2.png) | ![image](https://user-images.githubusercontent.com/3973243/62871749-f5f4cc00-bd13-11e9-9513-e45fc108981f.png) | |
| Remove icons in the contact search selectors | ![image](https://user-images.githubusercontent.com/3973243/62873534-7ec13700-bd17-11e9-91cf-9a16063bd893.png) |  ![image](https://user-images.githubusercontent.com/3973243/62945115-03728a80-bdd6-11e9-94e1-943851cb0c79.png) | Yes, applied globally |


# Technical Overview

## Applying shadows globally

As per https://github.com/civicrm/org.civicrm.shoreditch/pull/402 we applied shadows to the `h3` + `.crm-block` pair (please see the PR for more info). In this PR we extract these styles to apply them globally. It also seemed that some styles from https://github.com/civicrm/org.civicrm.shoreditch/pull/402 were not actually needed. This was thoroughly tested.

```css
.page-civicrm-civirule {
  position: relative;
  z-index: -3;

  #page {
    z-index: -2;
```

^ this has been removed.

## Case Search

This page looks totally different in Vanilla Civi and this is because we destruct the table into blocks:

```css
.crm-accordion-body .form-layout {
  display: block;
  ...

  > tbody:first-child {
    display: block;

    > tr {
      display: block;

      > td {
        display: block;
        ...

        > label:first-child {
          display: block;
```
^ This is a requirement.

## Other changes

Changes other than the ones described above are too trivial, hopefully are self-explanatory and may not worth description.

# Comments

We also now ignore `.DS_Store` files in git.

# Tests

- Manual
- BackstopJS 