### PR TITLE
SHOR-139: CiviRules and GDPR fixes

### DIFF
--- a/scss/civicrm/common/_block-shadows.scss
+++ b/scss/civicrm/common/_block-shadows.scss
@@ -9,13 +9,14 @@
  * just a single shadow underneath the pair.
  */
 
-// Need that otherwise shadows will be cropped on the top and the bottom
-#crm-main-content-wrapper {
-  position: relative;
-  z-index: 0;
-}
-
-*:not(.crm-form-block) {
+// We need this mixin because we want to apply these styles to the
+// h3+.crm-block pairs that not only are deep children of .crm-container,
+// but are also *direct* children of that div. The `.crm-container` is added
+// by Gulp, so we cannot use `&` operator because there is no actual parent
+// in SCSS, hence we have to use this mixin to use it for both cases:
+// .crm-container >h3:not(.crm-severity-info)
+// .crm-container *:not(.crm-form-block)>h3:not(.crm-severity-info)
+@mixin block-shadows-for-h3-crm-form-block-pair () {
   > h3:not(.crm-severity-info) {
     &,
     + .crm-block {
@@ -36,6 +37,19 @@
       }
     }
   }
+}
+
+// Need that otherwise shadows will be cropped on the top and the bottom
+#crm-main-content-wrapper,
+#crm-container {
+  position: relative;
+  z-index: 0;
+}
+
+@include block-shadows-for-h3-crm-form-block-pair();
+
+*:not(.crm-form-block) {
+  @include block-shadows-for-h3-crm-form-block-pair();
 }
 
 h3::before {

--- a/scss/civicrm/common/_block-shadows.scss
+++ b/scss/civicrm/common/_block-shadows.scss
@@ -52,4 +52,8 @@ h3 + .crm-form-block {
     // Need to discard the background otherwise this block will have sharp edges
     background-color: transparent !important;
   }
+
+  .dataTables_wrapper {
+    box-shadow: none;
+  }
 }

--- a/scss/civicrm/contact/pages/_rules.scss
+++ b/scss/civicrm/contact/pages/_rules.scss
@@ -1,6 +1,6 @@
 /* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type, selector-max-id */
 
-.page-civicrm-civirule {
+#{civi-page('civirule')} {
   // "CiviRules Add Rule" and "CiviRules Update Rule" pages
   &.page-civicrm-civirule-form-rule {
     .crm-civirule-rule_label-block,

--- a/scss/civicrm/contact/pages/_rules.scss
+++ b/scss/civicrm/contact/pages/_rules.scss
@@ -60,6 +60,7 @@
   // "CiviRules Add Condition", "CiviRules Add Action" and
   // "CiviRules Edit Action Parameters" pages
   &.page-civicrm-civirule-form-rule-condition,
+  &.page-civicrm-civirule-form-condition,
   &.page-civicrm-civirule-form-rule-action,
   &.page-civicrm-civirule-form-action {
     .crm-form-block {

--- a/scss/civicrm/contact/pages/_rules.scss
+++ b/scss/civicrm/contact/pages/_rules.scss
@@ -87,15 +87,6 @@
       width: 20px;
     }
   }
-
-  // "CiviRules Edit Condition parameters" pages
-  &.page-civicrm-civirule-form-condition-datachangedcomparison,
-  &.page-civicrm-civirule-form-condition-datacomparison,
-  &.page-civicrm-civirule-form-condition-activity-contact-record-type {
-    .crm-form-block {
-      @include block-form();
-    }
-  }
 }
 
 // "Find CiviRules Rules" page


### PR DESCRIPTION
# Overview

This PR fixes multiple visual issues in CiviRules and GDPR extensions. Please see the Changes sections for more info.

# Changes

| What | Before  | After | Any global styling? |
| ------------- | ------------- | ------------- | ------------- |
| CiviRules - missing padding in one of forms | ![image](https://user-images.githubusercontent.com/3973243/63260719-99486280-c279-11e9-9e83-6ec81cbbbbb2.png) | ![image](https://user-images.githubusercontent.com/3973243/63259518-82544100-c276-11e9-9e94-94b5a31fa2b0.png) | No, isolated to the specific CiviRules form |
| GDPR - Any contact > GDPR Tab - Unneeded shadow  | ![Alexia Adams _ civi16newby (3)](https://user-images.githubusercontent.com/3973243/63260517-12938580-c279-11e9-83ed-993094b84acf.png) | ![Alexia Adams _ civi16newby (1)](https://user-images.githubusercontent.com/3973243/63259641-dfe88d80-c276-11e9-8499-aa415ed795d1.png) | Yes, it's applied globally |
| GDPR - Contacts > Dashboard - Unneeded shadow  | ![image](https://user-images.githubusercontent.com/3973243/63260267-59cd4680-c278-11e9-8e17-f612fd3e25fa.png) | ![image](https://user-images.githubusercontent.com/3973243/63260137-11158d80-c278-11e9-998b-7e905d21a99c.png) | Yes, it's applied globally |

# Technical Details

## CiviRules

Previously we had fixes for some specific forms like `.page-civicrm-civirule-form-condition-datachangedcomparison`, the problem was that these classes are not hardcoded and can vary. So now we apply to `.page-civicrm-civirule-form-condition`. This also removes all the specific classes rules which clean the code up.

## GDPR

### Data Tables

`.dataTables_wrapper` should not have shadows if it is inside already styled h3+.crm-form-block pair.

### h3+.crm-form-block pair as a direct .crm-container's child

As we now isolate styles to CiviCRM, we have a `.crm-container` prefix set in Gulp:

```js
gulp.task('sass:civicrm', function buildCiviCRMCSS () {
  return gulp.src('scss/civicrm/custom-civicrm.scss')
    ...
    .pipe(postcss([
      postcssPrefix({
        prefix: '.crm-container ',
```

This now creates a style like this:

```css
.crm-container *:not(.crm-form-block)>h3:not(.crm-severity-info)
```

This will **not** apply if the h3+.crm-form-block pair is a **direct** child of `.crm-container`. Unfortunately, this is how it is in the last block at GDPR Dashboard. So, we need to create a style `.crm-container > h3...`.

We cannot use `&` because there is no parent `.crm-container` in SCSS (remember, the prefix is set by Gulp, not by SCSS), so we need to use mixin and then apply it both directly and inside `*:not(.crm-form-block)>`.

```css
@mixin block-shadows-for-h3-crm-form-block-pair () { ... }

...

@include block-shadows-for-h3-crm-form-block-pair();

*:not(.crm-form-block) {
  @include block-shadows-for-h3-crm-form-block-pair();
}
```

# Tests

Manual + Full BackstopJS.