### PR TITLE
SHOR-152: Fix shadows on unusual <h3> + <div> pairs

### DIFF
--- a/scss/civicrm/_mixins.scss
+++ b/scss/civicrm/_mixins.scss
@@ -1,6 +1,7 @@
 /* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type, selector-max-id */
 
 @import 'mixins/accordion';
+@import 'mixins/alpha-filter';
 @import 'mixins/advanced-multiselect';
 @import 'mixins/block-form';
 @import 'mixins/border-box';

--- a/scss/civicrm/administer/contribute/_contribute.scss
+++ b/scss/civicrm/administer/contribute/_contribute.scss
@@ -3,12 +3,8 @@
 &#{civi-page('admin-contribute')},
 &#{civi-page('admin-pcp')} {
   #alpha-filter {
-    @include box-shadow($box-shadow);
-    background: $crm-white;
-    border-radius: $border-radius-base $border-radius-base 0 0;
+    @include alpha-filter();
     margin-bottom: 0;
-    margin-top: 10px;
-    padding: 15px 10px 10px;
   }
 
   #crm-main-content-wrapper {

--- a/scss/civicrm/administer/contribute/_contribute.scss
+++ b/scss/civicrm/administer/contribute/_contribute.scss
@@ -2,16 +2,13 @@
 
 &#{civi-page('admin-contribute')},
 &#{civi-page('admin-pcp')} {
-  .crm-container {
-    div#alpha-filter {
-      @include box-shadow($box-shadow);
-      background: $crm-white;
-      border-bottom: 1px solid $crm-grayblue-dark;
-      border-radius: $border-radius-base $border-radius-base 0 0;
-      margin-bottom: 0;
-      margin-top: 10px;
-      padding: 15px 10px 10px;
-    }
+  #alpha-filter {
+    @include box-shadow($box-shadow);
+    background: $crm-white;
+    border-radius: $border-radius-base $border-radius-base 0 0;
+    margin-bottom: 0;
+    margin-top: 10px;
+    padding: 15px 10px 10px;
   }
 
   #crm-main-content-wrapper {
@@ -22,7 +19,22 @@
   }
 }
 
+&#{civi-page('admin-pcp')} {
+  #alpha-filter {
+    border-bottom: 1px solid $crm-grayblue-dark;
+  }
+}
+
 &#{civi-page('admin-contribute')} {
+  #configure_contribution_page {
+    box-shadow: $box-shadow;
+
+    #alpha-filter,
+    .dataTables_wrapper {
+      box-shadow: none;
+    }
+  }
+
   .crm-actions-ribbon {
     margin-bottom: 20px !important;
   }

--- a/scss/civicrm/common/_block-shadows.scss
+++ b/scss/civicrm/common/_block-shadows.scss
@@ -48,7 +48,7 @@
     + .form-item {
       padding-bottom: 0;
 
-      > .selector tr:last-child {
+      > .selector tbody tr:last-child {
         border-bottom: 0 !important;
       }
     }

--- a/scss/civicrm/common/_block-shadows.scss
+++ b/scss/civicrm/common/_block-shadows.scss
@@ -1,7 +1,7 @@
 /* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type, selector-max-id */
 
 /**
- * Applies proper shadows to the <h3> + <div class="crm-block"> pair.
+ * Applies proper shadows to the <h3> + <div class="crm-block"> (and others) pairs.
  *
  * @NOTE
  * If you apply shadows to these elements directly (not via :before pseudoclass),
@@ -20,7 +20,9 @@
   > h3:not(.crm-severity-info) {
     &,
     + .crm-block,
-    + .form-item {
+    + .form-item,
+    + .dataTables_wrapper,
+    + script + .dataTables_wrapper {
       position: relative;
 
       // Discard direct shadows
@@ -70,19 +72,23 @@ h3::before {
   border-radius: #{$border-radius-base} #{$border-radius-base} 0 0 !important;
 }
 
-h3 + .crm-form-block,
-h3 + .form-item {
-  &,
-  &::before {
-    border-radius: 0 0 #{$border-radius-base} #{$border-radius-base} !important;
-  }
+h3 {
+  + .crm-form-block,
+  + .form-item,
+  + .dataTables_wrapper,
+  + script + .dataTables_wrapper {
+    &,
+    &::before {
+      border-radius: 0 0 #{$border-radius-base} #{$border-radius-base} !important;
+    }
 
-  .crm-submit-buttons {
-    // Need to discard the background otherwise this block will have sharp edges
-    background-color: transparent !important;
-  }
+    .crm-submit-buttons {
+      // Need to discard the background otherwise this block will have sharp edges
+      background-color: transparent !important;
+    }
 
-  .dataTables_wrapper {
-    box-shadow: none;
+    .dataTables_wrapper {
+      box-shadow: none;
+    }
   }
 }

--- a/scss/civicrm/common/_block-shadows.scss
+++ b/scss/civicrm/common/_block-shadows.scss
@@ -19,10 +19,15 @@
 @mixin block-shadows-for-h3-crm-form-block-pair () {
   > h3:not(.crm-severity-info) {
     &,
-    + .crm-block {
-      // Discard direct shadows
-      box-shadow: none !important;
+    + .crm-block,
+    + .form-item {
       position: relative;
+
+      // Discard direct shadows
+      &,
+      > .selector {
+        box-shadow: none !important;
+      }
 
       &::before {
         bottom: 0;
@@ -34,6 +39,15 @@
         top: 0;
         // This is needed to place the shadows underneath so they do not overlap
         z-index: -1;
+      }
+    }
+
+    // Discard unneeded paddings and borders
+    + .form-item {
+      padding-bottom: 0;
+
+      > .selector tr:last-child {
+        border-bottom: 0 !important;
       }
     }
   }
@@ -56,7 +70,8 @@ h3::before {
   border-radius: #{$border-radius-base} #{$border-radius-base} 0 0 !important;
 }
 
-h3 + .crm-form-block {
+h3 + .crm-form-block,
+h3 + .form-item {
   &,
   &::before {
     border-radius: 0 0 #{$border-radius-base} #{$border-radius-base} !important;

--- a/scss/civicrm/common/_titles.scss
+++ b/scss/civicrm/common/_titles.scss
@@ -19,6 +19,7 @@ h3 {
 .crm-form-block {
   > h3:first-child {
     @include panel-header();
+    box-shadow: none;
     margin-bottom: 10px;
   }
 

--- a/scss/civicrm/contact/pages/_events.scss
+++ b/scss/civicrm/contact/pages/_events.scss
@@ -500,12 +500,8 @@
     }
   }
 
-  div#alpha-filter {
-    @include box-shadow($box-shadow);
-    background: $crm-white;
-    border-radius: $border-radius-base $border-radius-base 0 0;
-    margin-bottom: 0;
-    padding: 15px 10px 10px;
+  #alpha-filter {
+    @include alpha-filter();
   }
 
   .action-link {

--- a/scss/civicrm/contact/pages/_memberships.scss
+++ b/scss/civicrm/contact/pages/_memberships.scss
@@ -717,8 +717,15 @@
   }
 }
 
-#{civi-page('member')} .CRM_Member_Form_Search h3:first-of-type {
-  margin-top: 0;
+#{civi-page('member')} {
+  .CRM_Member_Form_Search h3:first-of-type {
+    margin-top: 0;
+  }
+
+  // Fixes the space between tables at /civicrm/member?reset=1
+  table.report + .spacer {
+    height: $crm-standard-gap;
+  }
 }
 
 // Adhoc: fixes the <h3> margin

--- a/scss/civicrm/mixins/_alpha-filter.scss
+++ b/scss/civicrm/mixins/_alpha-filter.scss
@@ -1,0 +1,7 @@
+@mixin alpha-filter() {
+  @include box-shadow($box-shadow);
+  background: $crm-white;
+  border-radius: $border-radius-base $border-radius-base 0 0;
+  margin-bottom: 0;
+  padding: #{$crm-standard-gap / 4 * 3} #{$crm-standard-gap / 2} #{$crm-standard-gap / 2};
+}


### PR DESCRIPTION
# Overview

This PR fixes issues with shadows on some pages where the markup is not standard so global fixes from https://github.com/civicrm/org.civicrm.shoreditch/pull/402 cannot be applied. Shadows are fixed on the following pages:

- CiviMember
- CiviEvent
- Manage Contribution Pages

As a side effect, the following pages also have been automatically fixed:

- Contacts Full-text Search

Please see the Changes section for more info.

# Changes

| What | Before  | After | Any global styling? |
| ------------- | ------------- | ------------- | ------------- |
| Manage Contribution Pages - Shadows | ![Manage Contribution Pages _ civi16newby (2)](https://user-images.githubusercontent.com/3973243/63275936-521e9980-c29a-11e9-99f6-6cefe88e037a.png) | ![Manage Contribution Pages _ civi16newby (1)](https://user-images.githubusercontent.com/3973243/63275253-159e6e00-c299-11e9-8d6e-74b75b8394ac.png) | Yes |
| CiviEvent - Shadows | ![CiviEvent _ civi16newby (1)](https://user-images.githubusercontent.com/3973243/63276078-96119e80-c29a-11e9-9033-9488c7709856.png) | ![CiviEvent _ civi16newby](https://user-images.githubusercontent.com/3973243/63275357-4e3e4780-c299-11e9-8d77-364e3c5d3d7f.png) | Yes |
| CiviMember - Gap and shadows | ![CiviMember _ civi16newby (1)](https://user-images.githubusercontent.com/3973243/63275989-6cf10e00-c29a-11e9-8fd9-ddd4c3466500.png) | ![CiviMember _ civi16newby](https://user-images.githubusercontent.com/3973243/63275738-f81dd400-c299-11e9-8553-cd2e794f33f1.png) | Shadows - yes. Gap - no, locally. |
| 🎉 Contacts Full-text Search (**side-effect**) | ![Full-text Search _ civi16newby](https://user-images.githubusercontent.com/3973243/63276350-189a5e00-c29b-11e9-8df1-35a4d3ce5abc.png) | ![Full-text Search _ civi16newby (1)](https://user-images.githubusercontent.com/3973243/63276588-8a72a780-c29b-11e9-8329-41c447faaeaf.png) | Yes |

# Technical Details

For shadows we extend the `h3 + .crm-form-block` pairs to other "unusual" markups, but those that still can be met sometimes in CiviCRM:

```css
@mixin block-shadows-for-h3-crm-form-block-pair () {
  > h3:not(.crm-severity-info) {
    &,
    /* Already existed */
    + .crm-block,
    /* Just added */
    + .form-item,
    + .dataTables_wrapper,
    + script + .dataTables_wrapper {
```

Because it is applied globally it also automatically fixed the Contacts Full-text Search page.

# Tests

Manual + Full BackstopJS suite.