### PR TITLE
SHOR-152: Fix misc issues

### DIFF
--- a/scss/civicrm/common/_block-shadows.scss
+++ b/scss/civicrm/common/_block-shadows.scss
@@ -19,10 +19,8 @@
 @mixin block-shadows-for-h3-crm-form-block-pair () {
   > h3:not(.crm-severity-info) {
     &,
-    + .crm-block,
-    + .form-item,
-    + .dataTables_wrapper,
-    + script + .dataTables_wrapper {
+    + div,
+    + script + div {
       position: relative;
 
       // Discard direct shadows
@@ -73,10 +71,8 @@ h3::before {
 }
 
 h3 {
-  + .crm-form-block,
-  + .form-item,
-  + .dataTables_wrapper,
-  + script + .dataTables_wrapper {
+  + div,
+  + script + div {
     &,
     &::before {
       border-radius: 0 0 #{$border-radius-base} #{$border-radius-base} !important;

--- a/scss/civicrm/common/_block-shadows.scss
+++ b/scss/civicrm/common/_block-shadows.scss
@@ -59,7 +59,7 @@
 #crm-main-content-wrapper,
 #crm-container {
   position: relative;
-  z-index: 0;
+  z-index: 1;
 }
 
 @include block-shadows-for-h3-crm-form-block-pair();

--- a/scss/civicrm/common/_forms.scss
+++ b/scss/civicrm/common/_forms.scss
@@ -343,3 +343,7 @@ input.error {
 .crm-container > .crm-section.form-item {
   margin-bottom: $crm-gap-medium;
 }
+
+input.hasDatepicker::placeholder {
+  color: transparent;
+}

--- a/scss/civicrm/common/_help.scss
+++ b/scss/civicrm/common/_help.scss
@@ -1,7 +1,9 @@
+/* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type, selector-max-id, scss/at-extend-no-missing-placeholder, property-no-vendor-prefix */
+
 .help,
 #help {
   background: $alert-success-bg;
-  border: none;
+  border: solid 1px $brand-success;
   border-radius: $border-radius-base;
   color: $gray-darker;
   padding: 10px;

--- a/scss/civicrm/contact/_detail.scss
+++ b/scss/civicrm/contact/_detail.scss
@@ -262,6 +262,7 @@
 
     .crm-summary-display_name {
       float: left;
+      margin-left: $crm-standard-gap;
       padding: 22px 0; // centering name vertically
     }
 
@@ -610,6 +611,10 @@
 
 
 .crm-inline-edit {
+  &.form {
+    background-color: $crm-gray-clay !important;
+  }
+
   form {
     .crm-content {
       margin-left: 0 !important;

--- a/scss/civicrm/contact/_header.scss
+++ b/scss/civicrm/contact/_header.scss
@@ -54,7 +54,6 @@
     background: $crm-page-topbar-bg;
     color: $crm-white;
     min-height: 110px; // min-height is needed as we use float inside
-    padding-left: 20px;
     position: relative;
   }
 

--- a/scss/civicrm/contact/pages/_contributions.scss
+++ b/scss/civicrm/contact/pages/_contributions.scss
@@ -966,3 +966,18 @@ form.CRM_Contribute_Form_ContributionCharts {
     }
   }
 }
+
+.contact-summary-contribute-tab {
+  .ui-tabs-nav {
+    background-color: $crm-white;
+    border: solid 1px $crm-grayblue-dark;
+
+    .ui-tabs-tab {
+      background-color: transparent;
+
+      &.ui-tabs-active {
+        background-color: $gray-light;
+      }
+    }
+  }
+}

--- a/scss/civicrm/contact/pages/_contributions.scss
+++ b/scss/civicrm/contact/pages/_contributions.scss
@@ -856,6 +856,10 @@ form.CRM_Contribute_Form_ContributionCharts {
 
   #mainTabContainer {
     @include box-shadow($crm-form-layout-shadow-lower);
+
+    + .spacer {
+      height: $crm-standard-gap;
+    }
   }
 
   .crm-pager {

--- a/scss/civicrm/contact/pages/_contributions.scss
+++ b/scss/civicrm/contact/pages/_contributions.scss
@@ -776,6 +776,15 @@
 }
 
 form.CRM_Contribute_Form_ContributionCharts {
+  h3 + div {
+    background-color: $crm-white;
+  }
+
+  .crm-pager,
+  table.selector {
+    box-shadow: none !important;
+  }
+
   .ui-tabs-nav {
     background: $crm-white;
     border: 0;
@@ -850,14 +859,21 @@ form.CRM_Contribute_Form_ContributionCharts {
   }
 
   .crm-pager {
-    @include box-shadow($crm-form-layout-shadow-lower);
-    background: $gray-lighter;
     line-height: 1.7em;
     margin: 0;
     padding: 7px 0;
 
     > .element-right {
+      margin-right: $crm-standard-gap !important;
       margin-top: 3px;
+    }
+
+    + .form-item {
+      padding: $crm-standard-gap !important;
+    }
+
+    .crm-pager-nav {
+      padding-left: 0;
     }
   }
 
@@ -874,7 +890,6 @@ form.CRM_Contribute_Form_ContributionCharts {
     > tbody > tr > td + .crm-pager {
       border-radius: 0 0 $panel-border-radius $panel-border-radius;
       border-top: 1px solid $crm-background;
-      box-shadow: $crm-form-item-shadow;
       margin-top: 0;
     }
 

--- a/scss/civicrm/contact/pages/_manage-groups.scss
+++ b/scss/civicrm/contact/pages/_manage-groups.scss
@@ -137,6 +137,18 @@
 }
 
 #{civi-page('group')} {
+  .crm-group-search-form-block #DataTables_Table_0_wrapper {
+    box-shadow: none;
+    margin-left: -#{$crm-standard-gap};
+    margin-right: -#{$crm-standard-gap};
+    margin-top: $crm-standard-gap * 2;
+
+    .crm-datatable-pager-top {
+      background-color: transparent;
+      border-radius: 0;
+    }
+  }
+
   .help {
     margin: 0 0 20px;
 

--- a/scss/civicrm/contact/pages/_manage-groups.scss
+++ b/scss/civicrm/contact/pages/_manage-groups.scss
@@ -137,6 +137,14 @@
 }
 
 #{civi-page('group')} {
+  #searchForm {
+    border: solid 1px $crm-grayblue-dark;
+    border-radius: 0 0 $panel-border-radius $panel-border-radius;
+    border-top: 0;
+    margin-bottom: $crm-standard-gap / 2;
+    padding: $crm-standard-gap;
+  }
+
   .crm-group-search-form-block #DataTables_Table_0_wrapper {
     box-shadow: none;
     margin-left: -#{$crm-standard-gap};
@@ -158,8 +166,9 @@
   }
 
   .crm-submit-buttons {
+    border-top: 0 !important;
     margin-bottom: 20px;
-    padding: 0;
+    padding: 0 !important;
 
     a.newGroup.button {
       @extend %btn-civi-primary;

--- a/scss/civicrm/contact/pages/_memberships.scss
+++ b/scss/civicrm/contact/pages/_memberships.scss
@@ -280,6 +280,10 @@
   .action-link {
     display: none;
   }
+
+  .crm-contact-contribute-contributions > table.selector {
+    margin-top: -#{$crm-standard-gap} !important;
+  }
 }
 
 .CRM_Member_Form_Search {

--- a/scss/civicrm/contact/pages/_memberships.scss
+++ b/scss/civicrm/contact/pages/_memberships.scss
@@ -286,6 +286,16 @@
   }
 }
 
+.CRM_Contribute_Form_AdditionalPayment {
+  border: solid 1px $gray-lighter;
+  border-radius: $border-radius-base;
+
+  // Makes amount and currency appear on the same line
+  tbody > tr > td:first-child {
+    white-space: nowrap;
+  }
+}
+
 .CRM_Member_Form_Search {
   .crm-button-type-refresh {
     .crm-i {


### PR DESCRIPTION
# Overview

This PR fixes miscellaneous issues with Shoreditch. Please see the **Changes** section below for more info.

# Changes

| What | Before  | After | Any global styling? |
| ------------- | ------------- | ------------- | ------------- |
| CiviContribute: shadows and gaps | ![CiviContribute _ civi16newby](https://user-images.githubusercontent.com/3973243/63429007-d98e1900-c410-11e9-9128-900719a46343.png) | ![CiviContribute _ civi16newby (1)](https://user-images.githubusercontent.com/3973243/63435065-20ced680-c41e-11e9-9f69-936cb5123c44.png) | Yes |
| Manage Groups: paddings, gaps and the search form | ![Manage Groups _ civi16newby](https://user-images.githubusercontent.com/3973243/63434266-abaed180-c41c-11e9-8e05-95788a158572.png) | ![Manage Groups _ civi16newby (1)](https://user-images.githubusercontent.com/3973243/63435125-43f98600-c41e-11e9-882d-11016742e966.png) | No |
| Contact > Contributions + Green help | ![Alexia Adams _ civi16newby (4)](https://user-images.githubusercontent.com/3973243/63434441-fe888900-c41c-11e9-919c-2974833384ac.png)| ![Alexia Adams _ civi16newby (6)](https://user-images.githubusercontent.com/3973243/63435196-62f81800-c41e-11e9-986a-4558d3a9fe04.png) | Contributions tab - locally. Green help - globally. |
| Contact > Edit name inline form: overall styling | ![Alexia Adams _ civi16newby (5)](https://user-images.githubusercontent.com/3973243/63434654-68089780-c41d-11e9-9ff1-903f1a8ccc80.png) | ![Alexia Adams _ civi16newby (9)](https://user-images.githubusercontent.com/3973243/63435740-5aeca800-c41f-11e9-82bb-41dc40a745af.png) | No |
| Membership > Find membership > View a membership: gap | ![Alexia Adams _ civi16newby (11)](https://user-images.githubusercontent.com/3973243/63437478-82913f80-c422-11e9-88fd-aac908ecdaac.png)| ![Alexia Adams _ civi16newby (7)](https://user-images.githubusercontent.com/3973243/63435309-9cc91e80-c41e-11e9-845f-e7b3026fa443.png) | No |
| Datepicker inputs (global) > double icons fix | ![image](https://user-images.githubusercontent.com/3973243/63434792-aaca6f80-c41d-11e9-98df-1169372ff298.png) | ![image](https://user-images.githubusercontent.com/3973243/63435335-a783b380-c41e-11e9-89ea-b253a402324f.png) | Yes |

# Technical Details

## Shadows

It was decided to apply shadows globally for the `<h3> + <¯\_(ツ)_/¯>`:

```css
@mixin block-shadows-for-h3-crm-form-block-pair () {
  > h3:not(.crm-severity-info) {
    &,
    /*
      + .crm-block
      + .form-item,
      + .dataTables_wrapper,
      + script + .dataTables_wrapper {
    */
    + div,
    + script + div {
```
The reason is that we have different markups all over the place, but they always share this pattern:

```css
h3 + div
/* Plus in rare cases there is a <script> tag between them */
```

This was tested with BackstopJS.

The rest of the changes may not worth being mentioned here because they are just plain stylings.

## Tests

Manual + BackstopJS.