### PR TITLE
SHOR-152: Misc issues

### DIFF
--- a/scss/civicrm/_variables.scss
+++ b/scss/civicrm/_variables.scss
@@ -27,6 +27,9 @@ $crm-light-gray-color: #818c97;
 
 $font-family-fontawesome: 'FontAwesome';
 
+$crm-font-weight-normal: 400;
+$crm-font-weight-bold: 600;
+
 $crm-min-width: 1005px;
 $crm-max-width: 1504px;
 $crm-min-lg-width: 1505px;

--- a/scss/civicrm/_variables.scss
+++ b/scss/civicrm/_variables.scss
@@ -10,7 +10,6 @@ $crm-main-menu-padding-base: 13px;
 $crm-main-menu-padding-small: 8px;
 
 $crm-checkbox-shadow: inset 0 0 3px 0 rgba(0, 0, 0, 0.2);
-$crm-contribute-form-shadow: 0 0 16px 1px rgba(0, 0, 0, 0.1);
 $crm-form-item-shadow: 0 3px 6px 0 rgba(48, 40, 40, 0.25);
 $crm-form-layout-shadow: 0 3px 18px 0 rgba(48, 40, 40, 0.25);
 $crm-form-layout-shadow-lower: 0 8px 18px 0 rgba(48, 40, 40, 0.25);

--- a/scss/civicrm/_variables.scss
+++ b/scss/civicrm/_variables.scss
@@ -9,6 +9,7 @@ $crm-control-height: 30px;
 $crm-main-menu-padding-base: 13px;
 $crm-main-menu-padding-small: 8px;
 
+$crm-box-shadow-light: 0 0 16px 1px rgba(0, 0, 0, 0.1);
 $crm-checkbox-shadow: inset 0 0 3px 0 rgba(0, 0, 0, 0.2);
 $crm-form-item-shadow: 0 3px 6px 0 rgba(48, 40, 40, 0.25);
 $crm-form-layout-shadow: 0 3px 18px 0 rgba(48, 40, 40, 0.25);

--- a/scss/civicrm/common/_backgrounds.scss
+++ b/scss/civicrm/common/_backgrounds.scss
@@ -3,13 +3,13 @@
 .page-civicrm {
   %block-with-shadow {
     background: $crm-white;
-    box-shadow: 0 0 16px 1px rgba(0, 0, 0, 0.1);
+    box-shadow: $box-shadow;
   }
 
   #crm-main-content-wrapper {
     background: $crm-background !important;
   }
-  
+
   .crm-container {
     .crm-form-block {
       @extend %block-with-shadow;

--- a/scss/civicrm/common/_base.scss
+++ b/scss/civicrm/common/_base.scss
@@ -249,14 +249,14 @@
   .font-size12pt {
     color: $gray-darker;
     font-size: $font-size-h2;
-    font-weight: 600;
+    font-weight: $crm-font-weight-bold;
     padding-bottom: 10px;
   }
 
   .font-size11pt {
     color: $gray-darker;
     font-size: $font-size-base;
-    font-weight: 600;
+    font-weight: $crm-font-weight-bold;
   }
 }
 

--- a/scss/civicrm/common/_base.scss
+++ b/scss/civicrm/common/_base.scss
@@ -149,6 +149,12 @@
     box-shadow: $box-shadow;
     margin-bottom: 20px;
 
+    // Sometimes there are .dataTables_wrapper > .dataTables_wrapper
+    // blocks that produce double shadows
+    > .dataTables_wrapper {
+      box-shadow: none;
+    }
+
     table.dataTable {
       box-shadow: none !important;
       max-width: 100%;

--- a/scss/civicrm/common/_base.scss
+++ b/scss/civicrm/common/_base.scss
@@ -150,7 +150,7 @@
     margin-bottom: 20px;
 
     // Sometimes there are .dataTables_wrapper > .dataTables_wrapper
-    // blocks that produce double shadows
+    // blocks that produce double shadows.
     > .dataTables_wrapper {
       box-shadow: none;
     }

--- a/scss/civicrm/common/_block-shadows.scss
+++ b/scss/civicrm/common/_block-shadows.scss
@@ -9,6 +9,28 @@
  * just a single shadow underneath the pair.
  */
 
+@mixin block-shadows-for-pair () {
+  position: relative;
+
+  // Discard direct shadows
+  &,
+  > .selector {
+    box-shadow: none !important;
+  }
+
+  &::before {
+    bottom: 0;
+    box-shadow: $box-shadow;
+    content: '';
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+    // This is needed to place the shadows underneath so they do not overlap
+    z-index: -1;
+  }
+}
+
 // We need this mixin because we want to apply these styles to the
 // h3+.crm-block pairs that not only are deep children of .crm-container,
 // but are also *direct* children of that div. The `.crm-container` is added
@@ -21,25 +43,7 @@
     &,
     + div,
     + script + div {
-      position: relative;
-
-      // Discard direct shadows
-      &,
-      > .selector {
-        box-shadow: none !important;
-      }
-
-      &::before {
-        bottom: 0;
-        box-shadow: $box-shadow;
-        content: '';
-        left: 0;
-        position: absolute;
-        right: 0;
-        top: 0;
-        // This is needed to place the shadows underneath so they do not overlap
-        z-index: -1;
-      }
+      @include block-shadows-for-pair();
     }
 
     // Discard unneeded paddings and borders
@@ -50,6 +54,13 @@
         border-bottom: 0 !important;
       }
     }
+  }
+}
+
+*:not(.crm-accordion-wrapper) > .crm-accordion-header {
+  &,
+  + .crm-accordion-body {
+    @include block-shadows-for-pair();
   }
 }
 

--- a/scss/civicrm/common/_buttons.scss
+++ b/scss/civicrm/common/_buttons.scss
@@ -408,3 +408,12 @@ button {
     }
   }
 }
+
+// We style only plain buttons which are <div>s with `crm-button` class
+// and do *not* have `crm-button-type-*` class. <span>s should not be touched.
+// We do *not* extend to `%btn-civi` because we want the height to be preserved.
+// Because of that we need to additionally discard the text shadow though.
+div.crm-button:not([class*='crm-button-type']) {
+  @extend %btn-civi-primary;
+  text-shadow: none;
+}

--- a/scss/civicrm/common/_buttons.scss
+++ b/scss/civicrm/common/_buttons.scss
@@ -415,7 +415,7 @@ button {
 // Because of that we need to additionally discard the text shadow though.
 div,
 button {
-  &.crm-button:not([class*='crm-button-type']) {
+  &.crm-button:not([class*='crm-button-type-']) {
     @extend %btn-civi-primary;
     text-shadow: none;
   }

--- a/scss/civicrm/common/_buttons.scss
+++ b/scss/civicrm/common/_buttons.scss
@@ -409,11 +409,14 @@ button {
   }
 }
 
-// We style only plain buttons which are <div>s with `crm-button` class
+// We style only plain buttons which are <div>s/<button>s with `crm-button` class
 // and do *not* have `crm-button-type-*` class. <span>s should not be touched.
 // We do *not* extend to `%btn-civi` because we want the height to be preserved.
 // Because of that we need to additionally discard the text shadow though.
-div.crm-button:not([class*='crm-button-type']) {
-  @extend %btn-civi-primary;
-  text-shadow: none;
+div,
+button {
+  &.crm-button:not([class*='crm-button-type']) {
+    @extend %btn-civi-primary;
+    text-shadow: none;
+  }
 }

--- a/scss/civicrm/common/_forms.scss
+++ b/scss/civicrm/common/_forms.scss
@@ -347,3 +347,7 @@ input.error {
 input.hasDatepicker::placeholder {
   color: transparent;
 }
+
+fieldset:not(.collapsed) > legend {
+  margin-bottom: $crm-standard-gap !important;
+}

--- a/scss/civicrm/common/_modals.scss
+++ b/scss/civicrm/common/_modals.scss
@@ -163,4 +163,8 @@
   .dataTables_wrapper {
     box-shadow: none;
   }
+
+  .crm-form-block h3 {
+    padding: $crm-table-form-cell-padding 0 !important;
+  }
 }

--- a/scss/civicrm/common/_wizard.scss
+++ b/scss/civicrm/common/_wizard.scss
@@ -17,7 +17,7 @@ ul.wizard-bar {
     color: $gray-darker !important;
     display: inline-block !important;
     font-size: $font-size-base !important;
-    font-weight: 600;
+    font-weight: $crm-font-weight-bold;
     height: 62px !important;
     line-height: 62px !important;
     padding: 0 20px !important;

--- a/scss/civicrm/contact/_collapse.scss
+++ b/scss/civicrm/contact/_collapse.scss
@@ -1,9 +1,9 @@
 // Collapse
 .crm-collapsible {
   background: $crm-white;
-  box-sizing: border-box;
-  box-shadow: $box-shadow;
   border-radius: 0;
+  box-shadow: $box-shadow;
+  box-sizing: border-box;
   margin-top: 14px;
   padding: 15px 20px !important;
 
@@ -19,18 +19,18 @@
 
   .collapsible-title {
     background-image: none !important;
-    color: $gray-darker;
-    font-family: "Open Sans";
-    font-size: 18px;
-    font-weight: 600;
-    padding: 0;
     border: 0;
+    color: $gray-darker;
+    font-family: 'Open Sans';
+    font-size: 18px;
+    font-weight: $crm-font-weight-bold;
+    padding: 0;
 
     &:hover {
       color: $gray-darker;
     }
 
-    &:before {
+    &::before {
       @include fa-icon(13px, '\f078');
       margin-right: 5px;
     }
@@ -38,7 +38,7 @@
 
   &.collapsed {
     .collapsible-title {
-      &:before {
+      &::before {
         @include fa-icon(13px, '\f054');
       }
     }

--- a/scss/civicrm/contact/_detail.scss
+++ b/scss/civicrm/contact/_detail.scss
@@ -52,7 +52,7 @@
 
   div.crm-summary-row {
     div.crm-label {
-      font-weight: 600;
+      font-weight: $crm-font-weight-bold;
 
       &,
       a {

--- a/scss/civicrm/contact/pages/_contact-dedupefind.scss
+++ b/scss/civicrm/contact/pages/_contact-dedupefind.scss
@@ -62,9 +62,6 @@
   }
 
   #searchOptions input[type='text'] {
-    @include input-text();
-    border: solid 1px $crm-grayblue-darker;
-    height: $input-height-small;
-    padding: $crm-input-padding;
+    @include input-text-bootstrap();
   }
 }

--- a/scss/civicrm/contact/pages/_contributions.scss
+++ b/scss/civicrm/contact/pages/_contributions.scss
@@ -28,7 +28,7 @@
   .CRM_Contribute_Form_Task_Delete {
     background: $crm-white;
     border-radius: $border-radius-small;
-    box-shadow: $crm-contribute-form-shadow;
+    box-shadow: $box-shadow;
     margin-top: 15px;
 
     + p {

--- a/scss/civicrm/contact/pages/_contributions.scss
+++ b/scss/civicrm/contact/pages/_contributions.scss
@@ -846,7 +846,12 @@ form.CRM_Contribute_Form_ContributionCharts {
       box-shadow: none;
 
       td {
-        padding: 10px 20px;
+        padding: #{$crm-standard-gap / 2} $crm-standard-gap;
+      }
+
+      th {
+        padding-left: $crm-standard-gap;
+        padding-right: $crm-standard-gap;
       }
     }
 

--- a/scss/civicrm/contact/pages/_contributions.scss
+++ b/scss/civicrm/contact/pages/_contributions.scss
@@ -728,7 +728,7 @@
         td {
           &.label {
             color: $gray-darker;
-            font-weight: 600;
+            font-weight: $crm-font-weight-bold;
           }
 
           &:first-child {

--- a/scss/civicrm/contact/pages/_contributions.scss
+++ b/scss/civicrm/contact/pages/_contributions.scss
@@ -550,6 +550,15 @@
 }
 
 .CRM_Contribute_Form_Contribution {
+  // Hides "Alternatively, you can use a price set" text
+  #totalAmountBlock {
+    display: none !important;
+  }
+
+  #priceset {
+    margin-top: $crm-standard-gap / 2;
+  }
+
   .crm-accordion-header {
     font-family: $font-family-base;
     font-weight: $crm-font-weight-h1 !important;

--- a/scss/civicrm/contact/pages/_manage-groups.scss
+++ b/scss/civicrm/contact/pages/_manage-groups.scss
@@ -286,16 +286,6 @@
   }
 
   .ui-dialog .CRM_Group_Form_Edit .crm-form-block {
-    margin: 0 -20px;
-
-    .action-link {
-      margin-left: 20px;
-    }
-
-    .help {
-      margin: 10px 20px 20px;
-    }
-
     table tr {
       border-bottom: 0 !important;
 
@@ -309,10 +299,6 @@
           padding: 8px 0;
         }
       }
-    }
-
-    .crm-submit-buttons {
-      margin: 20px 0 0 !important;
     }
 
     #s2id_visibility::after {

--- a/scss/civicrm/contact/pages/_memberships.scss
+++ b/scss/civicrm/contact/pages/_memberships.scss
@@ -3,8 +3,6 @@
 #{civi-page('contact')} {
   #memberships,
   #inactive-memberships {
-    border-radius: $panel-border-radius;
-    box-shadow: $box-shadow;
     margin-bottom: 20px;
   }
 

--- a/scss/civicrm/contact/pages/_new-email.scss
+++ b/scss/civicrm/contact/pages/_new-email.scss
@@ -59,7 +59,7 @@
         td {
           &.label {
             color: $gray-darker;
-            font-weight: 600;
+            font-weight: $crm-font-weight-bold;
           }
         }
       }

--- a/scss/civicrm/contact/pages/_new-individual.scss
+++ b/scss/civicrm/contact/pages/_new-individual.scss
@@ -267,4 +267,11 @@
     font-size: $font-size-base;
     font-weight: $crm-font-weight-bold;
   }
+
+  // Styling Postcode Lookup extension input
+  #addressLookup input {
+    @include input-text-bootstrap();
+    // Makes the placeholder fully visible
+    min-width: 220px;
+  }
 }

--- a/scss/civicrm/contact/pages/_new-individual.scss
+++ b/scss/civicrm/contact/pages/_new-individual.scss
@@ -112,6 +112,7 @@
   }
 
   .contact_information-section {
+    position: relative;
     table-layout: fixed;
 
     tr {
@@ -125,6 +126,25 @@
         }
       }
     }
+
+    .email-signature {
+      // Position the "> Signature" button to the right side of the table
+      > .collapsible-title {
+        position: absolute;
+        right: 0;
+        top: $crm-standard-gap;
+        // We need to discard the width to attach the "button"
+        // to the very right edge of the table. Because it is not overflown,
+        // it still we be visible and clickable
+        width: 0;
+      }
+
+      #signatureBlock1 {
+        margin-top: $crm-standard-gap / 2;
+      }
+    }
+
+
   }
 
   #commPrefs {

--- a/scss/civicrm/contact/pages/_new-individual.scss
+++ b/scss/civicrm/contact/pages/_new-individual.scss
@@ -248,4 +248,23 @@
       }
     }
   }
+
+  #contactDetails {
+    tr:not([id]) {
+      // Makes labels bold. We cannot use a specific selector because
+      // labels are just text inside <td>s. We also ignore <tr>s with "id"
+      // attributes because those definitely do not contain labels
+      font-weight: $crm-font-weight-bold;
+
+      // Discarding bold font for links
+      a {
+        font-weight: $crm-font-weight-normal;
+      }
+    }
+  }
+
+  .email-signature > .collapsible-title {
+    font-size: $font-size-base;
+    font-weight: $crm-font-weight-bold;
+  }
 }

--- a/scss/civicrm/contact/pages/_new-individual.scss
+++ b/scss/civicrm/contact/pages/_new-individual.scss
@@ -135,7 +135,7 @@
         top: $crm-standard-gap;
         // We need to discard the width to attach the "button"
         // to the very right edge of the table. Because it is not overflown,
-        // it still we be visible and clickable
+        // it still we be visible and clickable.
         width: 0;
       }
 
@@ -273,7 +273,7 @@
     tr:not([id]) {
       // Makes labels bold. We cannot use a specific selector because
       // labels are just text inside <td>s. We also ignore <tr>s with "id"
-      // attributes because those definitely do not contain labels
+      // attributes because those definitely do not contain labels.
       font-weight: $crm-font-weight-bold;
 
       // Discarding bold font for links

--- a/scss/civicrm/contact/pages/_new-price-set.scss
+++ b/scss/civicrm/contact/pages/_new-price-set.scss
@@ -91,7 +91,7 @@
       margin: 20px 0;
 
       td {
-        padding: 10px 20px !important;
+        padding: #{$crm-standard-gap / 2} !important;
       }
     }
   }

--- a/scss/civicrm/financial/_financial-batch.scss
+++ b/scss/civicrm/financial/_financial-batch.scss
@@ -13,10 +13,6 @@
         &:hover {
           color: $gray-darker;
         }
-
-        + div {
-          margin: 10px 0;
-        }
       }
 
       &:not(.collapsed) {

--- a/scss/civicrm/mixins/_accordion.scss
+++ b/scss/civicrm/mixins/_accordion.scss
@@ -4,7 +4,7 @@
   background-image: none !important;
   color: $gray-darker;
   font-family: $font-family-base;
-  font-weight: 600;
+  font-weight: $crm-font-weight-bold;
   line-height: 18px;
   margin-bottom: 0;
   padding: 16px 20px;

--- a/scss/civicrm/mixins/_civicrm-table.scss
+++ b/scss/civicrm/mixins/_civicrm-table.scss
@@ -50,18 +50,9 @@
 
 /*
  * Styles a table with a H3 header:
- * - removes shadows from the table and the header
- * - adds a shadow to their wrapper
  * - removes unnecessary borders from the column headers
  */
 @mixin civicrm-table-with-header() {
-  box-shadow: $box-shadow;
-
-  h3,
-  table {
-    box-shadow: none !important;
-  }
-
   .columnheader {
     border: 0 !important;
     border-bottom: 1px solid $crm-grayblue-dark !important;

--- a/scss/civicrm/mixins/_input-text.scss
+++ b/scss/civicrm/mixins/_input-text.scss
@@ -13,3 +13,14 @@
     border-color: $brand-primary;
   }
 }
+
+@mixin input-text-bootstrap() {
+  @include input-text();
+  @include input-text-bootstrap-styles();
+}
+
+@mixin input-text-bootstrap-styles() {
+  border: solid 1px $crm-grayblue-darker;
+  height: $input-height-small;
+  padding: $crm-input-padding;
+}

--- a/scss/civicrm/mixins/_panel-header.scss
+++ b/scss/civicrm/mixins/_panel-header.scss
@@ -1,7 +1,7 @@
 /* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type, selector-max-id, scss/at-extend-no-missing-placeholder, property-no-vendor-prefix */
 
 @mixin panel-header() {
-  @include box-shadow($crm-contribute-form-shadow);
+  @include box-shadow($box-shadow);
   background: $gray-lighter;
   border-bottom: 1px solid $crm-grayblue-dark;
   border-radius: $border-radius-base $border-radius-base 0 0;

--- a/scss/jquery/mixins/_ui-dialog.scss
+++ b/scss/jquery/mixins/_ui-dialog.scss
@@ -119,7 +119,7 @@
 
     border: 0 !important;
     border-bottom: 1px solid $crm-grayblue-dark !important;
-    box-shadow: $box-shadow;
+    box-shadow: $crm-box-shadow-light;
     color: $gray-darker !important;
     font-family: $font-family-base;
     position: relative;
@@ -190,7 +190,7 @@
     background: $gray-lighter;
     border-radius: 0 0 $border-radius-base $border-radius-base;
     border-top: 1px solid $crm-grayblue-dark !important;
-    box-shadow: $box-shadow;
+    box-shadow: $crm-box-shadow-light;
     display: block;
     font-family: $font-family-base;
     margin-left: 0;

--- a/scss/jquery/mixins/_ui-dialog.scss
+++ b/scss/jquery/mixins/_ui-dialog.scss
@@ -116,10 +116,10 @@
 
   .ui-dialog-titlebar {
     @extend .modal-header; /* stylelint-disable-line scss/at-extend-no-missing-placeholder */
-    
+
     border: 0 !important;
     border-bottom: 1px solid $crm-grayblue-dark !important;
-    box-shadow: $crm-contribute-form-shadow;
+    box-shadow: $box-shadow;
     color: $gray-darker !important;
     font-family: $font-family-base;
     position: relative;
@@ -127,7 +127,7 @@
 
     .ui-dialog-title {
       @extend .modal-title; /* stylelint-disable-line scss/at-extend-no-missing-placeholder */
-      
+
       font-family: $font-family-base;
       font-size: $font-size-h2;
       font-weight: $crm-font-weight-h2;
@@ -143,7 +143,7 @@
 
   .ui-dialog-content {
     @include calc(max-height, '100vh - 280px',!important);
-    
+
     background: $crm-white;
     color: $gray-darker;
     font-family: $font-family-base;
@@ -186,11 +186,11 @@
 
   .ui-dialog-buttonpane {
     @extend .modal-footer; /* stylelint-disable-line scss/at-extend-no-missing-placeholder */
-    
+
     background: $gray-lighter;
     border-radius: 0 0 $border-radius-base $border-radius-base;
     border-top: 1px solid $crm-grayblue-dark !important;
-    box-shadow: $crm-contribute-form-shadow;
+    box-shadow: $box-shadow;
     display: block;
     font-family: $font-family-base;
     margin-left: 0;


### PR DESCRIPTION
# Overview

This PR fixes miscellaneous issues with Shoreditch. Please see the **Changes** section below for more info.

# Changes

| What | Before  | After | Any global styling? |
| ------------- | ------------- | ------------- | ------------- |
| Mailing component - Accordion body padding | ![image](https://user-images.githubusercontent.com/3973243/63757952-e8624900-c8b2-11e9-9a0a-41c88701814d.png) | ![image](https://user-images.githubusercontent.com/3973243/63760564-78a28d00-c8b7-11e9-9c6a-ee361c559c94.png) | Yes |
| Dedupe exceptions - buttons are not styles | ![image](https://user-images.githubusercontent.com/3973243/63758059-1cd60500-c8b3-11e9-9a53-45be232f6818.png) |![image](https://user-images.githubusercontent.com/3973243/63760599-85bf7c00-c8b7-11e9-91b0-3b92204c483c.png) | Yes |
| New group modal with custom fields - paddings | ![image](https://user-images.githubusercontent.com/3973243/63758381-97068980-c8b3-11e9-9e09-7f08dbfdf2b3.png) | ![image](https://user-images.githubusercontent.com/3973243/63760641-996ae280-c8b7-11e9-979f-fcc26461fd0c.png)| Yes |
| New price field - table paddings | ![image](https://user-images.githubusercontent.com/3973243/63758630-fb294d80-c8b3-11e9-97f4-bc3693978050.png) | ![image](https://user-images.githubusercontent.com/3973243/63760687-b0113980-c8b7-11e9-9f53-1af543b4e35f.png) | No |
| New contribution - paddings and unnecessary label |![image](https://user-images.githubusercontent.com/3973243/63758737-2a3fbf00-c8b4-11e9-8003-c65193730419.png) | ![image](https://user-images.githubusercontent.com/3973243/63760923-244bdd00-c8b8-11e9-93b9-bd3019c3df87.png) | No |
| Dedupe Exceptions - shadows | ![image](https://user-images.githubusercontent.com/3973243/63758988-9fab8f80-c8b4-11e9-90e8-e7e6d8709556.png) | ![image](https://user-images.githubusercontent.com/3973243/63760943-32016280-c8b8-11e9-90a6-fe79f7e5ab8d.png) | Yes |
| New contact - label font weights | ![image](https://user-images.githubusercontent.com/3973243/63759072-ce296a80-c8b4-11e9-95c4-7652d5490361.png) | ![image](https://user-images.githubusercontent.com/3973243/63760970-3d548e00-c8b8-11e9-869c-54e478706737.png) | No |
| Contributions Dashboard - Table paddings | ![image](https://user-images.githubusercontent.com/3973243/63759488-835c2280-c8b5-11e9-964c-e74a4e414b84.png) |![image](https://user-images.githubusercontent.com/3973243/63761024-552c1200-c8b8-11e9-986f-d1907a1e61bd.png) | No |
| New contact - postcode lookup (extension) - input field | ![image](https://user-images.githubusercontent.com/3973243/63760252-e00c0d00-c8b6-11e9-82da-92a19d53126c.png) | ![image](https://user-images.githubusercontent.com/3973243/63761065-6412c480-c8b8-11e9-969a-6e8cc42854bd.png) | No |
| New contact - email signature | ![image](https://user-images.githubusercontent.com/3973243/63760304-fd40db80-c8b6-11e9-8a53-e7c20a43c2fb.png) | ![image](https://user-images.githubusercontent.com/3973243/63761091-71c84a00-c8b8-11e9-9c3c-9f3d40a6d6c2.png) | No |

# Technical Details

While most of the changes are trivial, this one may require attention:

## Styling the rest of buttons

Most CiviCRM buttons are styled by their distinct classes or containers, like here:

```css
&.crm-form-submit:not(.cancel) {
  @extend %btn-civi-primary;
}
```
However, there are some buttons that do not have these classes and are not even in the needed containers. For those we create this style:

```css
div.crm-button:not([class*='crm-button-type']) {
  @extend %btn-civi-primary;
  text-shadow: none;
}
```
We target only `div`s (for `span`s we will then have double styling because `span`s are nesting other `.crm-button` divs inside). We also do not target those which have explicit "types" via `crm-button-type-*` classes.

## Removing inconsistent shadow style

We now use the first shadow in favor of second (see screenshot below): 

![image](https://user-images.githubusercontent.com/3973243/63767343-4c8e0880-c8c5-11e9-8fc9-7ce729c41973.png)


## Tests

Manual + BackstopJS.