### PR TITLE
SHOR-152: Fix KAM menu search and collapsible headers

### DIFF
--- a/scss/civicrm/common/_buttons.scss
+++ b/scss/civicrm/common/_buttons.scss
@@ -413,10 +413,12 @@ button {
 // and do *not* have `crm-button-type-*` class. <span>s should not be touched.
 // We do *not* extend to `%btn-civi` because we want the height to be preserved.
 // Because of that we need to additionally discard the text shadow though.
-div,
-button {
-  &.crm-button:not([class*='crm-button-type-']) {
-    @extend %btn-civi-primary;
-    text-shadow: none;
+*:not(.crm-submit-buttons) {
+  > div,
+  > button {
+    &.crm-button:not([class*='crm-button-type-']) {
+      @extend %btn-civi-primary;
+      text-shadow: none;
+    }
   }
 }

--- a/scss/civicrm/common/_forms.scss
+++ b/scss/civicrm/common/_forms.scss
@@ -351,3 +351,8 @@ input.hasDatepicker::placeholder {
 fieldset:not(.collapsed) > legend {
   margin-bottom: $crm-standard-gap !important;
 }
+
+.crm-container .crm-collapsible .collapsible-title {
+  font-size: $font-size-base;
+  padding: #{$crm-standard-gap / 2} $crm-standard-gap;
+}

--- a/scss/civicrm/common/_main-menu.scss
+++ b/scss/civicrm/common/_main-menu.scss
@@ -10,15 +10,24 @@
 
   li {
     line-height: $item-line-height;
-    
+
     a {
       color: $gray-darker;
-    } 
+    }
+  }
+
+  #crm-qsearch > a:first-child {
+    background-color: $gray-lighter;
   }
 
   #crm-qsearch-input {
-    border-radius: $border-radius-base;
+    background-color: transparent;
+    border: 0;
     font-family: $font-family-base;
+
+    &:focus {
+      outline: none;
+    }
   }
 
   .crm-i {
@@ -98,7 +107,7 @@
     font-family: $font-family-base;
     font-size: $font-size-base;
     padding: $crm-main-menu-padding-base 0;
-    
+
     .ui-menu-item-wrapper {
       padding: $crm-main-menu-padding-small ($crm-main-menu-padding-base * 2) $crm-main-menu-padding-small $crm-main-menu-padding-base;
     }
@@ -108,5 +117,5 @@
       border: 0;
       margin: 0;
     }
-  }  
+  }
 }


### PR DESCRIPTION
# Overview

This PR fixes KAM menu search and collapsible headers. Please see the Changes section for more info.

# Changes

| What | Before  | After | Any global styling? |
| ------------- | ------------- | ------------- | ------------- |
| KAM Search input | ![image](https://user-images.githubusercontent.com/3973243/63788581-a276a680-c8ed-11e9-9c41-843c16b799d1.png) ![image](https://user-images.githubusercontent.com/3973243/63788848-1a44d100-c8ee-11e9-95e4-2af729cf107c.png) | ![image](https://user-images.githubusercontent.com/3973243/63788001-aa821680-c8ec-11e9-8338-9d134021428c.png) ![image](https://user-images.githubusercontent.com/3973243/63788030-b53cab80-c8ec-11e9-99cd-58c9d4dc3d5c.png) | Yes |
| Collapsible headers | ![image](https://user-images.githubusercontent.com/3973243/63788519-8a068c00-c8ed-11e9-9b7f-a1642f0cb5c8.png) | ![image](https://user-images.githubusercontent.com/3973243/63788329-32682080-c8ed-11e9-84d5-ca15bda625f0.png) | Yes |

# Extra
We also fix a regression due to https://github.com/civicrm/org.civicrm.shoreditch/pull/411. 

**Was:**
![image](https://user-images.githubusercontent.com/3973243/63789308-0057be00-c8ef-11e9-80ac-f23e802ca69e.png)

**Now:**

![image](https://user-images.githubusercontent.com/3973243/63789227-dacab480-c8ee-11e9-917e-9aa02ff0bf0b.png)

# Technical details

The only change worth mentioning is the regressions fix. We add a selector that we **don't** want to be picked up:

```
*:not(.crm-submit-buttons) {
  ...
```
We don't want to style these because they are already styled.

# Tests

Manual + BackstopJS.
