### PR TITLE
SHOR-151: Misc fixes

### DIFF
--- a/scss/civicrm/_variables.scss
+++ b/scss/civicrm/_variables.scss
@@ -3,6 +3,10 @@
 $crm-standard-gap: 20px;
 $crm-table-form-cell-padding: 4px;
 
+$crm-contact-info-block-min-height: 60px;
+$crm-contact-info-block-padding-top: 20px;
+$crm-contact-info-block-padding-bottom: 10px;
+
 $contact-avatar: 90px;
 $crm-control-height: 30px;
 

--- a/scss/civicrm/administer/communication-organisation/_message-templates.scss
+++ b/scss/civicrm/administer/communication-organisation/_message-templates.scss
@@ -8,10 +8,10 @@
       .spacer {
         display: none;
       }
+    }
 
-      .help {
-        margin: 20px 20px 0 !important;
-      }
+    #user .help {
+      margin-bottom: 0;
     }
   }
 }

--- a/scss/civicrm/common/_buttons.scss
+++ b/scss/civicrm/common/_buttons.scss
@@ -422,3 +422,11 @@ button {
     }
   }
 }
+
+.crm-container span.crm-button {
+  overflow: inherit;
+
+  > .crm-i {
+    margin-top: 7px;
+  }
+}

--- a/scss/civicrm/contact/_detail.scss
+++ b/scss/civicrm/contact/_detail.scss
@@ -257,6 +257,7 @@
   }
 
   #crm-contactname-content {
+    background-color: $crm-gray-clay;
     border: 0 !important;
     max-height: 70px;
 
@@ -611,10 +612,6 @@
 
 
 .crm-inline-edit {
-  &.form {
-    background-color: $crm-gray-clay !important;
-  }
-
   form {
     .crm-content {
       margin-left: 0 !important;

--- a/scss/civicrm/contact/_header.scss
+++ b/scss/civicrm/contact/_header.scss
@@ -53,7 +53,9 @@
   div.crm-summary-contactname-block {
     background: $crm-page-topbar-bg;
     color: $crm-white;
-    min-height: 110px; // min-height is needed as we use float inside
+    min-height: $crm-contact-info-block-min-height;
+    padding-bottom: $crm-contact-info-block-padding-bottom;
+    padding-top: $crm-contact-info-block-padding-top;
     position: relative;
   }
 

--- a/scss/civicrm/contact/pages/_contributions.scss
+++ b/scss/civicrm/contact/pages/_contributions.scss
@@ -411,6 +411,11 @@
 }
 
 #{civi-page('contact-view-contribution')} {
+  #crm-main-content-wrapper {
+    background-color: $crm-white;
+    box-shadow: $box-shadow;
+  }
+
   #branding {
     display: block;
   }
@@ -694,6 +699,23 @@
 }
 
 .CRM_Contribute_Form_ContributionView {
+  .crm-info-panel {
+    @include table-selector-full-style();
+
+    .selector {
+      box-shadow: none;
+    }
+  }
+
+  #Donor_Information__ {
+    border: 0;
+    padding: 0;
+
+    .crm-accordion-body {
+      box-shadow: none;
+    }
+  }
+
   .action-link {
     display: none;
   }

--- a/scss/civicrm/contact/pages/_events.scss
+++ b/scss/civicrm/contact/pages/_events.scss
@@ -271,10 +271,6 @@
 
 #{civi-dialog()} {
   #Participant {
-    .view-content {
-      margin: 0 -#{$crm-standard-gap};
-    }
-
     .td {
       line-height: 18px !important;
     }

--- a/scss/civicrm/contact/pages/_new-email.scss
+++ b/scss/civicrm/contact/pages/_new-email.scss
@@ -48,6 +48,10 @@
       }
     }
   }
+
+  #crm-display_relationship_type {
+    margin-top: $crm-standard-gap / 4;
+  }
 }
 
 .CRM_Contact_Form_Task_Email {

--- a/scss/civicrm/contact/pages/_relationships.scss
+++ b/scss/civicrm/contact/pages/_relationships.scss
@@ -2,7 +2,12 @@
 
 #{civi-page('contact')} {
   #contact-summary-relationship-tab {
+
     font-family: $font-family-base;
+    // Removes the gap between headers and tables
+    h3 + .help {
+      margin-bottom: 0;
+    }
 
     .action-link {
       line-height: 20px;

--- a/scss/civicrm/contact/pages/_relationships.scss
+++ b/scss/civicrm/contact/pages/_relationships.scss
@@ -44,10 +44,7 @@
 
       .crm-datatable-pager-bottom {
         background: $crm-gray-lightest;
-        border-radius: 0 0 $border-radius-child $border-radius-child;
-        line-height: 1.8em;
-        padding-bottom: 15px;
-        padding-top: 10px;
+        overflow: hidden;
 
         .dataTables_info,
         .dataTables_paginate {
@@ -67,7 +64,7 @@
 
       .dataTables_info {
         font: $font-size-base $font-family-base;
-        line-height: 2.3em;
+        margin-top: 0;
         padding-left: 20px;
         width: 49%;
       }

--- a/scss/civicrm/contact/pages/_tag-contacts.scss
+++ b/scss/civicrm/contact/pages/_tag-contacts.scss
@@ -177,6 +177,11 @@
           background: none;
         }
       }
+
+      // We don't want to indent the very first <ul>, just those that are nested
+      > ul ul {
+        margin-left: $crm-standard-gap / 4 * 5;
+      }
     }
   }
 }

--- a/scss/civicrm/contact/pages/_tag-contacts.scss
+++ b/scss/civicrm/contact/pages/_tag-contacts.scss
@@ -168,7 +168,7 @@
     box-shadow: $box-shadow;
 
     #tagtree {
-      padding: 20px;
+      padding-top: $crm-standard-gap;
 
       li {
         margin: 10px 0;
@@ -189,10 +189,12 @@
         th {
           @include panel-header;
           border-width: 0 0 1px;
+          box-shadow: none;
         }
 
         td {
           border: 0;
+          padding: $crm-standard-gap;
         }
       }
 
@@ -203,6 +205,7 @@
           border: 1px solid $crm-grayblue-darker;
           border-radius: $border-radius-base;
           height: 16px;
+          margin-right: $crm-standard-gap / 4;
           position: relative;
           top: 5px;
           width: 16px;

--- a/scss/civicrm/mailing/pages/_mailing-report.scss
+++ b/scss/civicrm/mailing/pages/_mailing-report.scss
@@ -40,22 +40,10 @@
   }
 
   table.crm-info-panel {
-    @include table-selector();
+    @include table-selector-full-style();
 
-    border: 0 !important;
-    border-radius: $border-radius-base;
     margin-left: -#{$crm-standard-gap} !important;
     width: calc(100% + #{$crm-standard-gap * 2});
-
-    td,
-    th {
-      background-color: transparent !important;
-    }
-
-    td.label {
-      color: $crm-black !important;
-      font-size: $font-size-base;
-    }
   }
 
   // We do not need striped tables here

--- a/scss/civicrm/mixins/_table-selector.scss
+++ b/scss/civicrm/mixins/_table-selector.scss
@@ -35,3 +35,20 @@
     }
   }
 }
+
+@mixin table-selector-full-style() {
+  @include table-selector();
+
+  border: 0 !important;
+  border-radius: $border-radius-base;
+
+  td,
+  th {
+    background-color: transparent !important;
+  }
+
+  td.label {
+    color: $crm-black !important;
+    font-size: $font-size-base;
+  }
+}

--- a/scss/jquery/overrides/_select2.scss
+++ b/scss/jquery/overrides/_select2.scss
@@ -248,18 +248,33 @@ $crm-jquery-select2-search-items-label-padding: 5px 10px;
       background: $crm-white;
     }
 
-    .Individual-icon {
+    .Individual-icon,
+    .Household-icon,
+    .Organization-icon {
       background: none;
       text-indent: 0;
 
-      &:before {
-        // Align with the original icon position
-        margin-left: 2px;
-        font-size: $font-size-medium;
+      &::before {
         display: block;
-        content: '\f007';
-        font-family: "FontAwesome";
+        font-family: 'FontAwesome';
+        // Align with the original icon position
+        font-size: $font-size-medium;
       }
+    }
+
+    .Individual-icon::before {
+      content: $fa-var-user;
+      margin-left: 2px;
+    }
+
+    .Household-icon::before {
+      content: $fa-var-home;
+      margin-left: 0;
+    }
+
+    .Organization-icon::before {
+      content: $fa-var-building;
+      margin-left: 1px;
     }
   }
 }

--- a/scss/jquery/overrides/_tabs.scss
+++ b/scss/jquery/overrides/_tabs.scss
@@ -18,6 +18,15 @@
       outline: none;
     }
 
+    &:not(.crm-contact-tabs-list) {
+      .ui-corner-all,
+      .ui-corner-top {
+        a {
+          height: 1.2em;
+        }
+      }
+    }
+
     .ui-corner-all,
     .ui-corner-top {
       background: $gray-lighter;


### PR DESCRIPTION
# Overview

This PR fixes miscellaneous issues with Shoreditch. Please see the **Changes** section below for more info.

# Changes

| What | Before  | After |
| ------------- | ------------- | ------------- |
| Contact add address (regression) | ![image](https://user-images.githubusercontent.com/3973243/63940978-82b4bf00-ca62-11e9-9836-2a1363af4b4e.png) | ![image](https://user-images.githubusercontent.com/3973243/63942511-ceb53300-ca65-11e9-805e-5c467557280b.png) |
| Contributions => Find contributions -> right click on view contribution and open in a new tab | ![View Contribution from Alexia Adams _ civi16newby](https://user-images.githubusercontent.com/3973243/63941059-b4c62100-ca62-11e9-8208-f4f2f7566ffb.png) | ![View Contribution from Alexia Adams _ civi16newby (1)](https://user-images.githubusercontent.com/3973243/63942697-22c01780-ca66-11e9-91b1-151b007c92fd.png) |
| Select contact - Organisation icons, Household icons | ![image](https://user-images.githubusercontent.com/3973243/63941162-e0490b80-ca62-11e9-987e-54c5cbb5029f.png) | ![image](https://user-images.githubusercontent.com/3973243/63942717-2eabd980-ca66-11e9-9e58-bc71f92bebc4.png)
| Administer > Communications > Message Templates - System workflow messages - gap after green message is missing | ![image](https://user-images.githubusercontent.com/3973243/63941371-65342500-ca63-11e9-9c26-2f7aeefcecc4.png) | ![image](https://user-images.githubusercontent.com/3973243/63942813-556a1000-ca66-11e9-89f9-aeb50f4acf97.png) | 
| Contacts -> Manage tags - additional line shown | ![image](https://user-images.githubusercontent.com/3973243/63941419-81d05d00-ca63-11e9-931c-ff334f054534.png) | ![image](https://user-images.githubusercontent.com/3973243/63942831-6155d200-ca66-11e9-8c52-15c0fb24d03f.png) |
| Advanced search -> Display results as -> Related contacts - gap between fields is missing | ![image](https://user-images.githubusercontent.com/3973243/63941497-b04e3800-ca63-11e9-8f1d-1194d9203906.png) | ![image](https://user-images.githubusercontent.com/3973243/63942852-6ca8fd80-ca66-11e9-8f88-f5b0949ef46f.png) | 
| Contact > Events > Submit credit card even registration - green box should not be full width | ![image](https://user-images.githubusercontent.com/3973243/63941589-dc69b900-ca63-11e9-8895-37a502c0b635.png) | ![image](https://user-images.githubusercontent.com/3973243/63942882-7cc0dd00-ca66-11e9-8390-f90599026b47.png) | 
| Search contact -> Single contact -> Tags tab - multiple layout issues | ![image](https://user-images.githubusercontent.com/3973243/63941696-08853a00-ca64-11e9-9a48-991547c718ed.png) | ![image](https://user-images.githubusercontent.com/3973243/63942941-96622480-ca66-11e9-8486-62836f4554d2.png)
| Reduce height of contact record header section | ![image](https://user-images.githubusercontent.com/3973243/63941746-23f04500-ca64-11e9-8ee5-44cb782eb1c5.png) | ![image](https://user-images.githubusercontent.com/3973243/63942959-a0842300-ca66-11e9-8460-01069554d34f.png) |
| Contact -> Relationships tab - avoid a gap and fix footer | ![Alexia Adams _ civi16newby (12)](https://user-images.githubusercontent.com/3973243/63941835-539f4d00-ca64-11e9-9645-6a2eea0fa9b7.png)  | ![Alexia Adams _ civi16newby (13)](https://user-images.githubusercontent.com/3973243/63943009-ba256a80-ca66-11e9-9bb3-51301ca81ce0.png) |
# Technical Details

All the changes are considered trivial (all just CSS styles), none may worth attention.

## Tests

Manual + BackstopJS.