### PR TITLE
SHOR-155: Enable Shoreditch As Backend Theme On Install

### DIFF
--- a/CRM/Shoreditch/Upgrader.php
+++ b/CRM/Shoreditch/Upgrader.php
@@ -7,23 +7,36 @@ use CRM_Shoreditch_ExtensionUtil as E;
 class CRM_Shoreditch_Upgrader extends CRM_Shoreditch_Upgrader_Base {
 
   /**
+   * Called on extension install.
+   */
+  public function install() {
+    $this->setShoreditchAsBackendTheme();
+  }
+
+  /**
+   * Set shoreditch as CiviCRM backend theme.
+   */
+  public function upgrade_0001() {
+    $this->setShoreditchAsBackendTheme();
+
+    return TRUE;
+  }
+
+  /**
    * 1. Removes "custom-civicrm.css" from the "custom css url" field
    * 2. Sets shoreditch as the backend theme only
    */
-  public function upgrade_0001() {
+  public function setShoreditchAsBackendTheme() {
     $customCSSUrl = Civi::settings()->get("customCSSURL");
-    
     if (strpos($customCSSUrl, 'org.civicrm.shoreditch') !== FALSE) {
       civicrm_api3('setting', 'create', [
         'customCSSURL' => ''
       ]);
     }
-  
+
     civicrm_api3('setting', 'create', [
       'theme_frontend' => 'default',
       'theme_backend' => 'shoreditch'
     ]);
-  
-    return TRUE;
   }
 }

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Once all the packages are installed `gulp sass` will be automatically invoked, w
 The theme includes two major components:
 
  * "`bootstrap.css`" is a build of Bootstrap based on the standard Bootstrap style-guide. It can be used with other CiviCRM extensions which satisfy the Bootstrap style-guide.
- * "`custom-civicrm.css`" is an optional replacement for "civicrm.css". It uses the same visual conventions and SCSS metadata, but it applies to existing core screens.
+ * "`custom-civicrm.css`" is a supplement to "civicrm.css". It uses the same visual conventions and SCSS metadata, but it applies to existing core screens.
 
 ### Using `bootstrap.css`
 
@@ -69,20 +69,6 @@ This extension provides the CSS for Bootstrap.  Other extensions should output c
 
 Note the use of `id="bootstrap-theme"`.  To avoid conflicts with CMS UIs, the CSS rules are
 restricted to `#bootstrap-theme`.
-
-### Using `custom-civicrm.css`
-
-This extension includes an optional file `custom-civicrm.css` which can replace the default
-`civicrm.css`.  This uses the same CSS classes as traditional CiviCRM screens, but the
-look-and-feel matches the Bootstrap look-and-feel.  It is implemented with the same SCSS variables
-and mixins. To use it, navigate to **Administer -> System Settings -> Resource URLs** And click on
-"Shoreditch" as the Custom CSS Url option.
-
-Or from the command line:
-
-```
-cv api setting.create customCSSURL=$(cv url -x shoreditch/css/custom-civicrm.css --out=list)
-```
 
 ## Contributing
 Want to report a bug, suggest enhancements, or contribute to the project? Please read [here](CONTRIBUTING.md)!

--- a/shoreditch.php
+++ b/shoreditch.php
@@ -28,6 +28,20 @@ function shoreditch_civicrm_xmlMenu(&$files) {
  */
 function shoreditch_civicrm_install() {
   _shoreditch_civix_civicrm_install();
+
+  // Unset "custom css url" (customCSSURL) field
+  $customCSSUrl = Civi::settings()->get("customCSSURL");
+  if (strpos($customCSSUrl, 'org.civicrm.shoreditch') !== FALSE) {
+    civicrm_api3('setting', 'create', [
+      'customCSSURL' => ''
+    ]);
+  }
+
+  // Set "shoreditch" as the backend theme.
+  civicrm_api3('setting', 'create', [
+    'theme_frontend' => 'default',
+    'theme_backend' => 'shoreditch'
+  ]);
 }
 
 /**

--- a/shoreditch.php
+++ b/shoreditch.php
@@ -28,20 +28,6 @@ function shoreditch_civicrm_xmlMenu(&$files) {
  */
 function shoreditch_civicrm_install() {
   _shoreditch_civix_civicrm_install();
-
-  // Unset "custom css url" (customCSSURL) field
-  $customCSSUrl = Civi::settings()->get("customCSSURL");
-  if (strpos($customCSSUrl, 'org.civicrm.shoreditch') !== FALSE) {
-    civicrm_api3('setting', 'create', [
-      'customCSSURL' => ''
-    ]);
-  }
-
-  // Set "shoreditch" as the backend theme.
-  civicrm_api3('setting', 'create', [
-    'theme_frontend' => 'default',
-    'theme_backend' => 'shoreditch'
-  ]);
 }
 
 /**
@@ -133,6 +119,13 @@ function shoreditch_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
  */
 function shoreditch_civicrm_themes(&$themes) {
   _shoreditch_civix_civicrm_themes($themes);
+}
+
+/**
+ * Implements hook_civicrm_postInstall().
+ */
+function shoreditch_civicrm_postInstall() {
+  _shoreditch_civix_civicrm_postInstall();
 }
 
 /**


### PR DESCRIPTION
### Overview
We need to shoreditch theme to be enabled as a theme on installing the extension,  following the [theme system](https://docs.civicrm.org/dev/en/latest/framework/theme/) introduced on CiviCRM v5.16.

### Before
The theme has to be set by going to civicrm/admin/setting/preferences/display?reset=1

### After 
![gif40](https://user-images.githubusercontent.com/36624620/64530933-e759fe80-d32b-11e9-83d4-d5e10c9918b2.gif)

### Details
In hook_civicrm_install, "custom css url" is unset (if relevant) and 'theme_backend' setting is set to 'shoreditch'. This is done following the upgrader we already have in place [here](https://github.com/civicrm/org.civicrm.shoreditch/blob/d9953d0aee35ab6cf28a53d07ebcead3c427b7cc/CRM/Shoreditch/Upgrader.php#L13-L28).