### PR TITLE
SE-12: Fix edit menu opening issue on nav links

### DIFF
--- a/scss/civicrm/common/_jstree.scss
+++ b/scss/civicrm/common/_jstree.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type */
+
 .jstree-default {
   .jstree-wholerow-hovered,
   .jstree-wholerow-clicked {
@@ -12,6 +14,7 @@
     border: 1px solid $crm-background;
     border-radius: $border-radius-base;
     padding: 0;
+    z-index: 1;
 
     li {
       > a {


### PR DESCRIPTION
## Overview
As a part of this PR the right click triggered menu is now appearing on administration navigation menu link.

## Before
![SE-12-before](https://user-images.githubusercontent.com/3340537/71795700-78887a00-306d-11ea-99f3-0ee9f6fbab75.gif)

## After
![SE-12-after](https://user-images.githubusercontent.com/3340537/71795689-6e667b80-306d-11ea-8dd8-aef70ede7175.gif)

## Technical Details
The sub menu was JS behaviour was intact, it was just that it's z-index was not set to the correct value
![SE-12-td](https://user-images.githubusercontent.com/3340537/71796267-e7ff6900-306f-11ea-9f9e-f5e3aaa4cec1.gif)

## Tests
Manual + BackstopJS.
