### PR TITLE
SE-14: Fix email popup spacing issue

### DIFF
--- a/scss/civicrm/search/pages/_send-email.scss
+++ b/scss/civicrm/search/pages/_send-email.scss
@@ -16,13 +16,6 @@
     padding: 0 20px;
   }
 
-  .crm-accordion-wrapper,
-  .crm-block > .crm-submit-buttons,
-  .crm-block > .form-layout-compressed {
-    margin-left: -20px !important;
-    margin-right: -20px !important;
-  }
-
   .crm-block > .crm-submit-buttons
   .crm-block > .form-layout-compressed {
     td.label {


### PR DESCRIPTION
## Overview
This PR fixes the send email popup horizontal alignment and fix the horizontal scrollbar

## Before
<img width="1144" alt="Screenshot 2020-01-07 at 7 00 11 PM" src="https://user-images.githubusercontent.com/3340537/71898820-40259080-3180-11ea-8b7c-1fd9efb7069a.png">

## After
<img width="915" alt="Screenshot 2020-01-07 at 6 34 42 PM" src="https://user-images.githubusercontent.com/3340537/71898834-4ca9e900-3180-11ea-83b9-2331c7c152d8.png">

## Technical Details
Extra -ve margin was added to the email confirmation popup elements for contacts screen.

The changes are added in https://github.com/civicrm/org.civicrm.shoreditch/commit/751749cd0#diff-847cbd69e30c848777dc4ee29cdf1813R17-R22, which now seems stale and unnecessary and hence removing them.

## Tests
Manual + BackstopJS.