### PR TITLE
SE-13: Fix contribution panel spacing on contacts contribution t…

### DIFF
--- a/scss/civicrm/contact/_detail.scss
+++ b/scss/civicrm/contact/_detail.scss
@@ -12,7 +12,7 @@
   }
 
   div.crm-contact-contribute-contributions {
-    padding-top: 20px !important;
+    margin-bottom: 20px;
   }
 
   .crm-summary-block {
@@ -86,6 +86,23 @@
   .CRM_Contribute_Form_Search {
     .action-link {
       line-height: normal;
+    }
+
+    .crm-contact-contribute-softcredit {
+      > p {
+        margin: 0;
+      }
+
+      .form-layout-compressed {
+        tr:first-child {
+          height: 50px;
+          line-height: 50px;
+
+          th {
+            padding-top: 0;
+          }
+        }
+      }
     }
 
     .form-layout-compressed {


### PR DESCRIPTION
## Overview 
This PR separates the panel spacing between soft credits and normal contributions on the contact contribution pane

## Before
<img width="1510" alt="Screenshot 2020-01-07 at 7 01 53 PM" src="https://user-images.githubusercontent.com/3340537/71899519-ecb44200-3181-11ea-94b0-c81febf7f093.png">

## After
<img width="1456" alt="Screenshot 2020-01-07 at 5 23 49 PM" src="https://user-images.githubusercontent.com/3340537/71974680-1a5bc280-3238-11ea-90cb-74a4af2f7484.png">


## Technical Details
Top padding is removed from the contribute box and bottom margin is applied and some spacing is adjusted for the soft credit panel too
The table cells of soft credit table are given equal height so that they look similar to contribution table

## Comments
Since the boxes are wrapped with `crm-block` class elements, all those elements had a small border radius and box shadow and hence touching and merging panels to each other was quite a complex and risky solution (considering the implication of the css changes)
So, to keep the UX good and give the impression that these both panes are different, a slight space between the panes of same category is kept. This is done in order to not overlap the box shadow of one pane to another , also if we merge the two panes, due to border radius it won't look good
<img width="878" alt="Screenshot 2020-01-07 at 7 21 09 PM" src="https://user-images.githubusercontent.com/3340537/71900019-f2f6ee00-3182-11ea-876c-6d847a2b48e3.png">
## Tests
Manual + BackstopJS.