### PR TITLE
SE-18: Fix the branch generation logic - remove 'v'

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -248,7 +248,7 @@ const PluginError = require('plugin-error');
    * @return {String}
    */
   function releaseBranchName () {
-    return `v${argv.ver}-rc`;
+    return `${argv.ver}-rc`;
   }
 }
 


### PR DESCRIPTION
## Overview 
This PR updates the branch name generated using `gulp release` command 
Currently, the branch name starts with `v` but this creates confusion while creating tags.
## Before/After
No visual changes introduced

## Notes
This is done in order to follow the new release process and remove confusion.