### PR TITLE
SE-15: Fix misc issues on activity panel and activity pane popup

### DIFF
--- a/scss/civicrm/common/_modals.scss
+++ b/scss/civicrm/common/_modals.scss
@@ -167,4 +167,16 @@
   .crm-form-block h3 {
     padding: $crm-table-form-cell-padding 0 !important;
   }
+
+  // Exceptional overrides for CRM_Activity_Form_Activity view block.
+  .CRM_Activity_Form_Activity {
+    > .crm-activity-view-block {
+      .crm-accordion-header,
+      .crm-accordion-body>table:not(.form-layout):not(.form-layout-compressed),
+      .crm-info-panel {
+        margin: 0;
+        width: 100%;
+      }
+    }
+  }
 }

--- a/scss/civicrm/contact/pages/_new-activity.scss
+++ b/scss/civicrm/contact/pages/_new-activity.scss
@@ -201,7 +201,7 @@
 #{civi-page('contact')} {
   #Activity {
     .crm-activity-form-block-assignee_contact_id td:not(.label) {
-      padding: 0 5px;
+      padding: 0;
     }
 
     #attachments tr {

--- a/scss/civicrm/contact/pages/_new-activity.scss
+++ b/scss/civicrm/contact/pages/_new-activity.scss
@@ -196,6 +196,10 @@
       }
     }
   }
+
+  .crm-info-panel {
+    table-layout: fixed;
+  }
 }
 
 #{civi-page('contact')} {

--- a/scss/civicrm/contact/pages/_new-activity.scss
+++ b/scss/civicrm/contact/pages/_new-activity.scss
@@ -172,7 +172,6 @@
     }
   }
 
-
   .crm-form-block > .crm-submit-buttons {
     margin-left: 0 !important;
     margin-right: 0 !important;
@@ -197,8 +196,47 @@
     }
   }
 
-  .crm-info-panel {
-    table-layout: fixed;
+  > .crm-activity-view-block {
+    > .crm-info-panel {
+      table-layout: fixed;
+
+      // Reset table td label styles in order to make the cell label layout
+      // formatted correctly with values associated with it.
+      td {
+        &.label {
+          display: table-cell !important;
+          line-height: 18px !important;
+          padding-bottom: 8.5px !important;
+          padding-top: 8.5px !important;
+          text-align: left !important;
+          white-space: normal !important;
+          width: 30% !important;
+
+          label {
+            margin-bottom: 0;
+          }
+
+          + td {
+            width: 70% !important;
+          }
+
+          .crm-container & {
+            vertical-align: top !important;
+          }
+        }
+      }
+    }
+  }
+
+  // Mimmick the styles for crm-accordion-body to reset padding from ui-modal
+  // accordion.
+  .crm-accordion-header {
+    &:not(.crm-master-accordion-header) {
+      +.crm-accordion-body {
+        box-shadow: none;
+        padding: 0 !important;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Overview
This PR fixes the spacing issue on assignee contact element on activity form and custom fields option value column alignment

## Before

#### Assignee field
<img width="558" alt="Screenshot 2020-01-17 at 12 23 05 PM" src="https://user-images.githubusercontent.com/3340537/72594126-b79bb280-392c-11ea-8f81-da7c508d9c29.png">

#### Custom fields
![image-20200121-105840](https://user-images.githubusercontent.com/3340537/76846603-c3d9b880-6866-11ea-8c19-5f432819fe70.png)


## After

#### Assignee field
<img width="606" alt="Screenshot 2020-01-17 at 1 05 11 PM" src="https://user-images.githubusercontent.com/3340537/72594172-d4d08100-392c-11ea-95cd-82f9204784aa.png">

#### Custom fields
<img width="585" alt="Screenshot 2020-01-17 at 1 18 37 PM" src="https://user-images.githubusercontent.com/3340537/72594187-e154d980-392c-11ea-8a1f-d2af43767ea1.png">

## Technical Details

#### Assignee field
This assignee field doesn't follow standard civicrm classes (another example of non standard HTML structure in core) and to fix this a patch was created in shoreditch in [Aug 2017 here](https://github.com/swastikpareek/org.civicrm.shoreditch/commit/751749cd0#diff-cba1f4ab8ef27ddb2acab0f0e81913bbR326). But since then shoreditch has evolved much and while writing new css fixes we might have forgot to update these patched css code and hence we had this issue.
<img width="1145" alt="Screenshot 2020-01-17 at 1 29 07 PM" src="https://user-images.githubusercontent.com/3340537/72594530-8ff91a00-392d-11ea-8ad5-0f6be94bf4b7.png">

Technically, this element had to have `view-value` class to match other ui styles on the page. since it didn't had this class so we have updated this selector with exact same styles than `view-value` class. So now it has `padding: 0` 

#### Custom fields
This issue was also due to incorrect HTML layout strategy. `.crm-info-panel` was added inside another `.crm-info-panel` and hence table layout was not rendered correctly. To fix this `table-layout` fixed was added forcefully to each `.crm-info-panel` inside acitivity form panel. Since this HTML can be found at other places (like activity view panel) 
`/civicrm/case/activity?action=view&id=636&reset=1&caseid=1`
This fix was needed on shoreditch. 
## Tests
Backstop JS and Manual tests

### Backstop JS report
*31 screens failed - All false alarms as no one is related with the changes*
<img width="485" alt="Screenshot 2020-01-20 at 6 23 20 PM" src="https://user-images.githubusercontent.com/3340537/72728394-4457a200-3bb3-11ea-98f6-533b80376d98.png">

###### False screen alarms 
* New CiviCRM Profile 
* Customize Data and Screens - Relationship Types 
* Customize Data and Screens - Gender Options 
* Customize Data and Screens - Individual contact suffixes Options 
* Customize Data and Screens - Instant Messenger (IM) screen-names Options 
* Customize Data and Screens - Mobile Phone Providers Options 
* Customize Data and Screens - Website Type Options 
* Communications - Preferred Communication Methods 
* Communications - Communication Style Options
* Communications - Email Greeting Type Options 
* Communications - Addressee Type Options 
* CiviMember - Membership Types 
* Civicase - Settings - New Case Type - Standard Timelines 
* Civicase - Settings - Redaction Rule Options 
* Civicase - Settings - Encounter Medium Options 
* Record Contribution 
* Find Contributions - Edit Payments Modal - Results 
* Premiums (Thank-you Gifts) 
* Contributions - Manage Price Set 
* Contributions - Manage Price Set - View and Edit Price Fields Set 
* Financial Types 
* Payment Methods Options 
* Dashboard - Configure 
* Event Type Options 
* Participant Role Options 
* Event Name Badge Layouts 
* Headers, Footers, and Automated Messages 
* Email - schedule/send via CiviMail 
* Search Results - Add Relationship Modal - more actions 
* Search Results - Record Activity Modal - more actions 
* Custom Searches - Date Added to CiviCRM 
# Update
This PR also fix the layout of the core activity popup and resets the correct table layout of the activity panel on cases.
## Need of the solution
This solution was developed initially for a quick client demo and quick release of shoreditch alpha-36 version. 
 But after getting hold of the real situation and discussing it within the team it has been realised that it doesn't only need the activity table on civicase to be correctly aligned but also needs the correct alignment of the core activity pane modal. So, this PR was extended to have the fix for that too.
Also, the table layout generated in the after screenshot was not fully usable as it only provides 50% to the table cell content section. And we needed a solution in which the label to value ratio should be 3:7. This PR implements that fix too along with some minor crm accordion header lateral alignment noticed on add/edit/view activity modal.

### Before - Activity panel on civicase
 See main before screenshot
### After - Activity panel on civicase
![SE-15 -after](https://user-images.githubusercontent.com/3340537/76824044-e86c6b00-683b-11ea-8289-45982aa269c4.gif)

### Before - Activity pane popup
<img width="762" alt="Screenshot 2020-03-17 at 10 33 35 AM" src="https://user-images.githubusercontent.com/3340537/76824053-f4f0c380-683b-11ea-84ec-5d2df24d62dd.png">

### After - Activity pane popup
<img width="866" alt="Screenshot 2020-03-17 at 10 26 56 AM" src="https://user-images.githubusercontent.com/3340537/76824071-fe7a2b80-683b-11ea-8cf4-cde8602de4e7.png">

### Before - CRM header alignment on modal
<img width="1304" alt="Screenshot 2020-03-17 at 1 12 27 PM" src="https://user-images.githubusercontent.com/3340537/76833293-0f816780-6851-11ea-8adb-beea4019493d.png">

### After - CRM header alignment on modal
<img width="1204" alt="Screenshot 2020-03-17 at 12 59 24 PM" src="https://user-images.githubusercontent.com/3340537/76833176-e3fe7d00-6850-11ea-8ca5-b7ea90956301.png">

### Technical Details
`.CRM_Activity_Form_Activity > .crm-activity-view-block > .crm-info-panel` doesn't only affect the activity panel on civicase but the core ones too. So, one solution fixed the table layout at both the places.
Also, to have the popup to take correct lateral padding some css which was responsible for resetting the padding of the content inside it was overriden just for the activity modal in `_modals.scss`.
Also, the `.label` inside `.crm-info-label` didn't have any style and was taking default `.label` styles from shoreditch and was getting `display: inline`. This was needed to be reset and other related css had to be written to make it appear like a consistent table cell inside the main table.
All these properties needed to have `!Important` because these properties were already applied using `#bootstrap-theme` namespace parent selector which is an id selector and has the higher specificity than cumulative class selectors.

### Tests
Manual tests and running backstop test - in progress
<img width="511" alt="Screenshot 2020-03-17 at 12 53 09 PM" src="https://user-images.githubusercontent.com/3340537/76832493-6ab25a80-684f-11ea-9a2c-4b0824778f8b.png">
#### Issues which are false alarms
* Custom Fields List 
* Edit Multiple Choice Options 
* New CiviCRM Profile 
* Customize Data and Screens - Relationship Types 
* Customize Data and Screens - Contact Types 
* Customize Data and Screens - Instant Messenger (IM) screen-names Options 
* Customize Data and Screens - Location Types (Home, Work...) 
* Customize Data and Screens - Mobile Phone Providers Options 
* Customize Data and Screens - Phone Type Options 
* Customize Data and Screens - Website Type Options 
* Communications - Postal Greeting Type Options 
* Communications - Addressee Type Options 
* System Settings - Connections 
* System Settings - Safe File Extension Options 
* CiviMember - Membership Types 
* Civicase - Settings - Redaction Rule Options 
* Civicase - Settings - Case Status Options 
* Record Contribution 
* Find Contributions - Results 
* Find Contributions - Edit contribution modal - Results 
* Find Contributions - Show Individual Payments - Results 
* Accounting Batch - Closed Batches 
* Premiums (Thank-you Gifts) 
* Contributions - Manage Price Set - View and Edit Price Fields Set 
* Contributions - Manage Price Set - View and Edit Price Fields Set - Disable price field Modal 
* Payment Methods Options 
* Accepted Credit Cards Options 
* Event Type Options 
* Participant Status 
* Participant Role Options 
* From Email Addresses 
* Email - schedule/send via CiviMail 
* Custom Searches - Date Added to CiviCRM 

#### Issues which are fixed in the PR
* Search Results - Record Activity Modal - more actions 
* Find Activities - View Modal - results 
* Find Activities - Edit Modal - results 