### PR TITLE
SE-19: Remove calendar input placeholders

### DIFF
--- a/js/add-missing-date-addons.js
+++ b/js/add-missing-date-addons.js
@@ -1,4 +1,4 @@
-CRM.$(function() {
+CRM.$(function () {
   'use strict';
 
   /**
@@ -9,12 +9,12 @@ CRM.$(function() {
    * Adds an datepicker addon to the given input
    * @param {Object} input The jQuery object for the input
    */
-  function addDateAddonToInput(input) {
+  function addDateAddonToInput (input) {
     CRM.$('<span class="addon fa fa-calendar"></span>')
       .insertAfter(input)
       .css('margin-top', input.css('margin-top'))
       .css('margin-bottom', input.css('margin-bottom'))
-      .on('click', function() {
+      .on('click', function () {
         input.focus();
       });
 
@@ -28,7 +28,7 @@ CRM.$(function() {
    * @param  {Object} input The jQuery object for the input
    * @param  {Object} addon The jQuery object for the addon
    */
-  function moveAddonToInputsSide(input, addon) {
+  function moveAddonToInputsSide (input, addon) {
     input.after(addon);
     addon.css('margin-right', 10);
   }
@@ -37,8 +37,8 @@ CRM.$(function() {
    * We're debouncing the callback to avoid calling the plugin multiple times
    * during DOM changes
    */
-  var observer = new MutationObserver(debounce(function() {
-    CRM.$('.crm-container input.hasDatepicker').each(function() {
+  var observer = new MutationObserver(debounce(function () {
+    CRM.$('.crm-container input.hasDatepicker').each(function () {
       var $this = CRM.$(this);
       var addon = $this.siblings('.addon');
       if (!addon.length && !$this.siblings('.input-group-addon').length) {
@@ -54,13 +54,13 @@ CRM.$(function() {
     subtree: true
   });
 
-  function debounce(fn, delay) {
+  function debounce (fn, delay) {
     var timer = null;
-    return function() {
+    return function () {
       var me = this;
       var args = arguments;
       clearTimeout(timer);
-      timer = setTimeout(function() {
+      timer = setTimeout(function () {
         fn.apply(me, args);
       }, delay);
     };

--- a/js/add-missing-date-addons.js
+++ b/js/add-missing-date-addons.js
@@ -6,10 +6,14 @@ CRM.$(function () {
    */
 
   /**
-   * Adds an datepicker addon to the given input
+   * Adds an datepicker addon to the given input. It also removes the calendar icon displayed
+   * as a placeholder for the input in favour of the add on button calendar icon.
+   *
    * @param {Object} input The jQuery object for the input
    */
   function addDateAddonToInput (input) {
+    var placeholderWithoutCalendar = input.attr('placeholder').replace('', '');
+
     CRM.$('<span class="addon fa fa-calendar"></span>')
       .insertAfter(input)
       .css('margin-top', input.css('margin-top'))
@@ -21,6 +25,7 @@ CRM.$(function () {
     input[0].style.setProperty('width', input.width() - 19 + 'px', 'important');
     input[0].style.setProperty('margin-right', 0, 'important');
     input.css('min-width', 'initial');
+    input.attr('placeholder', placeholderWithoutCalendar);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "semistandard": {
     "globals": [
       "CRM",
-      "jQuery"
+      "jQuery",
+      "MutationObserver"
     ],
     "ignore": [
       "base/js/*"


### PR DESCRIPTION
## Overview
This PR removes an extra calendar icon that was being shown as a placeholder for calendar inputs.

## Before
![Screen Shot 2020-02-13 at 11 25 02 PM](https://user-images.githubusercontent.com/1642119/74498849-4d891580-4eb8-11ea-924e-17ba0e8ed5ed.png)

## After
![Screen Shot 2020-02-13 at 11 22 54 PM](https://user-images.githubusercontent.com/1642119/74498853-511c9c80-4eb8-11ea-9663-cef28ef050cc.png)

## Technical details

It's important to know that the original calendar only has a placeholder and an input. The calendar button is added by a JS script that runs on start:
https://github.com/civicrm/org.civicrm.shoreditch/blob/master/js/add-missing-date-addons.js#L12

In order to remove the repeated calendar icon we remove the calendar icon:

```js
var placeholderWithoutCalendar = input.attr('placeholder').replace('', '');
```

The `` symbol is the font-awesome character used to display a calendar.

We use replace the icon with an empty string instead of replacing the whole placeholder attribute to avoid removing placeholder texts that the calendars might have. Current dates don't have placeholders apart from the calendar icons, but this method allows to add placeholder text to calendar inputs in the future.

## Tests

Ran BackstopJS tests (from [this repo](https://github.com/compucorp/backstopjs-config)). Came back as expected.