### PR TITLE
SE-24: Fix Email Screen Extra Padding

### DIFF
--- a/scss/civicrm/search/pages/_send-email.scss
+++ b/scss/civicrm/search/pages/_send-email.scss
@@ -12,10 +12,6 @@
     }
   }
 
-  .crm-contactEmail-form-block {
-    padding: 0 20px;
-  }
-
   .crm-block > .crm-submit-buttons
   .crm-block > .form-layout-compressed {
     td.label {


### PR DESCRIPTION
## Overview
This PR fixes the Send Email screen extra padding.

## Before
![2020-04-21 at 10 30 AM](https://user-images.githubusercontent.com/5058867/79827134-2e789980-83bb-11ea-8970-f63e20c1f4c6.jpg)

## After
![2020-04-21 at 10 31 AM](https://user-images.githubusercontent.com/5058867/79827183-4d772b80-83bb-11ea-82d7-0c67a887ae1d.jpg)

## Technical Details
This is a regression issue, caused by https://github.com/civicrm/org.civicrm.shoreditch/pull/431.
The code removed in the above PR, fixed the margin issues when used inside an modal, but it also break the same page, when outside of modal.

To fix this, removed the following code
```scss
.crm-contactEmail-form-block {	
  padding: 0 20px;	
}
```

There is no details available about why this code was specifically necesssary, so backstop tests were run to confirm that there are no regressions.