### PR TITLE
SE-25: Fix Group Contacts Header

### DIFF
--- a/scss/civicrm/contact/pages/_manage-groups.scss
+++ b/scss/civicrm/contact/pages/_manage-groups.scss
@@ -143,6 +143,7 @@
     border-top: 0;
     margin-bottom: $crm-standard-gap / 2;
     padding: $crm-standard-gap;
+    width: auto !important;
   }
 
   .crm-group-search-form-block #DataTables_Table_0_wrapper {


### PR DESCRIPTION
## Overview
This PR fixes the broken header in Group Contacts screen.

## Before
![2020-04-21 at 10 52 AM](https://user-images.githubusercontent.com/5058867/79828532-81078500-83be-11ea-8d03-9ff21bba93c3.jpg)

## After
![2020-04-21 at 10 52 AM](https://user-images.githubusercontent.com/5058867/79828351-30902780-83be-11ea-856a-b716c256734d.jpg)

## Technical Details
In `_manage-groups.scss`, added

```scss
#{civi-page('group')} {
  #searchForm {
  ...
  width: auto !important;
  }
}
```

Backstop tests were run, to ensure no regressions are present.