### PR TITLE
BASW-641: Fix width of the section title on add contribution page

### DIFF
--- a/scss/civicrm/_variables.scss
+++ b/scss/civicrm/_variables.scss
@@ -45,6 +45,9 @@ $crm-table-label-column-width: 150px;
 $crm-status-bar-no-top: 0 20px 20px;
 $crm-status-bar-no-bottom: 20px 20px 0;
 
+$crm-section-title-spacing-x: 20px;
+$crm-section-title-spacing-y: 11px;
+
 $fa-var-alert: '\f06a';
 $fa-var-info-msg: '\f05a';
 $fa-var-success: '\f00c';

--- a/scss/civicrm/contact/pages/_contributions.scss
+++ b/scss/civicrm/contact/pages/_contributions.scss
@@ -355,7 +355,7 @@
 
     legend {
       @include section-title;
-      width: 100%;
+      width: calc(100% - (2 * #{$crm-section-title-spacing-x}));
     }
 
     .pay-later_info-section {

--- a/scss/civicrm/mixins/_section-title.scss
+++ b/scss/civicrm/mixins/_section-title.scss
@@ -10,5 +10,5 @@
   font-family: $font-family-base;
   font-size: $font-size-base;
   line-height: 24px;
-  padding: 11px 20px;
+  padding: $crm-section-title-spacing-y $crm-section-title-spacing-x;
 }


### PR DESCRIPTION
## Overview 
This PR fixes the section titles width on the add contributions pages.

## Before
<img width="1680" alt="Screenshot 2020-05-25 at 3 03 16 PM" src="https://user-images.githubusercontent.com/3340537/82808794-52426a00-9ea8-11ea-924f-4772ec92dfec.png">

## After
<img width="1680" alt="Screenshot 2020-05-25 at 3 08 06 PM" src="https://user-images.githubusercontent.com/3340537/82808807-59697800-9ea8-11ea-809f-89a0bdcc4f80.png">

## Technical Details
The section titles (`legend` inside `.CRM_Contribute_Form_Contribution` wrapper div) were given width of `100%` to forcefully render them as full bleed, but mixin `section-title` was also adding some padding to it which was making the _effective width to be 100px + 2 * horizontal-padding-unit_.
To fix this width was reduced by 2 * horizontal-padding-unit. Since the horizontal padding was not saved as a SASS variable. New SASS variables are documented in `_variables.scss` viz. `$crm-section-title-spacing-x` and `$crm-section-title-spacing-y`.

The variables are replaced at the place of spacing and width calculations.

## Tests
Manual tests - Done
BackstopJS test - 5 Failed for contributions menu group
<img width="532" alt="Screenshot 2020-05-26 at 6 24 57 PM" src="https://user-images.githubusercontent.com/3340537/82903577-c9e2c880-9f7e-11ea-8363-24138fc4c587.png">

* Contributions - New Contribution - Correct one
* Find Contributions - Results - False alarms
* Find Contributions - Show Individual Payments - Results - False alarms
* Contributions - Manage Price Set - View and Edit Price Fields Set - False alarms
* Accepted Credit Cards Options - False alarms