### PR TITLE
Fix missing slide buttons in tables.

### DIFF
--- a/scss/civicrm/common/_base.scss
+++ b/scss/civicrm/common/_base.scss
@@ -118,9 +118,6 @@
   span.btn-slide {
     background: none;
     display: inline-block;
-    padding-right: 0 !important;
-    text-indent: -500em;
-    width: 5px;
 
     &::after {
       @include fa-icon($font-size-base, $fa-var-ellipsis-v, $gray-darker);


### PR DESCRIPTION
In the current latest version of CiviCRM (5.27.0) we noticed the slide buttons where missing inside the manage contribution pages and manage events tables. This pull request fixes this issue and also makes the label visible again.
I find it much more usable when the labels are visible. A user previously had to guess which options are underneath the bullets. This makes the available actions much clearer, also for less experienced users.

Any feedback is welcome!