### PR TITLE
package.json: allow higher nodejs versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "postinstall": "npx gulp copy && npx gulp sass"
   },
   "engines": {
-    "node": "10.15.3"
+    "node": ">=10.15.3"
   },
   "semistandard": {
     "globals": [


### PR DESCRIPTION
NodeJS v10 is quite old. This change makes it possible to use a more recent version. I tested with v12 LTS.