### PR TITLE
DRU-256: Fix actions menu icon visibility

### DIFF
--- a/scss/civicrm/common/_base.scss
+++ b/scss/civicrm/common/_base.scss
@@ -125,7 +125,9 @@
     &::after {
       @include fa-icon($font-size-base, $fa-var-ellipsis-v, $gray-darker);
       background: none;
+      position: absolute;
       right: -2px;
+      text-align: center;
       text-indent: 0;
       top: 0;
       width: 5px;


### PR DESCRIPTION
## Overview
There was a bug with **More** menu item of actions menu on most pages - it was not visible (but was present on the page) so it was not possible to click it and select some action. Now its fixed.

## Before
![image](https://user-images.githubusercontent.com/39520000/92124117-0dfb2a00-ee06-11ea-812d-69d327d68365.png)

## After
![image](https://user-images.githubusercontent.com/39520000/92124727-d0e36780-ee06-11ea-85de-3cfca6b82a9e.png)

## Technical Details
To fix the issue we set `position: absolute` to the icon (`::after` element), which was missing and is required to make `right: -2px` work. Also `text-align: center` is added to improve icon alignment inside container.

I've ran backstop tests to verify changes implemented. Some tests failed, but all of them are either expected (because of implemented changes) or false alarms. So we can go ahead with this.
P.S. If you would want to run backstop tests again make sure to add `"misMatchThreshold": 0` to your `backstop.tpl.json` file, otherwise backstop would not notice this small change.