### PR TITLE
MAE-369: Fix expand/collapse icons overlap

### DIFF
--- a/scss/civicrm/mixins/_expandable-table.scss
+++ b/scss/civicrm/mixins/_expandable-table.scss
@@ -127,6 +127,10 @@
       background: none;
       position: relative;
 
+      &::before {
+        opacity: 0;
+      }
+
       &::after {
         @include fa-icon($font-size-base, $fa-var-chevron-right);
         left: 0;


### PR DESCRIPTION
## Overview
There was an issue with expand/collapse icons - 2 icons overlapped each other, this issue appeared in any expandable tables. Now it's fixed.

## Before
![image](https://user-images.githubusercontent.com/39520000/94282782-e6a50200-ff58-11ea-8d80-034192d769c8.png)

## After
![image](https://user-images.githubusercontent.com/39520000/94282674-c412e900-ff58-11ea-9439-92bc7c12f646.png)

## Technical details
Here we had an interesting collision: icon from shoreditch theme set to `::after` element was overlaped by icon coming from native civicrm styles set to `::before` element.
First I was thinking to refactor shoreditch - move icon to `::before` element, but maybe `::after` element is used for a reason, as I don't have background here, I decided to keep the icon in `::after`.
Then I've tried couple of options of hiding `::before` element (civicrm icon): first I've set `display: none`, but got this:
![image](https://user-images.githubusercontent.com/39520000/94283839-37692a80-ff5a-11ea-8dd7-e90b7e837e37.png)
This element has `width: 1em` which acts like a margin between icon and text.
Setting `font-size: 0` causing similar issue.

So if we decided to keep this element, but hide it - let's use `opacity: 0` to fix this issue. Luckily there is `expandable-table` mixin which we can update to fix issue on all pages.

### Backstop tests
I've ran backstop tests and found no issues - all failed tests are false alarms.
At the same time there was something else:
1. All tests of `search-actions` group failed due to the `ENGINE ERROR: No node found for selector: #mark_x_151`.
1. Some tests failed due to the `Error: No node found for selector: ...`
1. Some tests failed due to the `TimeoutError: waiting for function failed: timeout 30000ms exceeded`.

I think it can be ignored for now as this fix can not really break anything and multiple tests confirmed that everything is fine.