### PR TITLE
CPS-322: Support new Button markup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3052,12 +3052,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3070,17 +3072,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3195,7 +3200,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3207,6 +3213,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3221,6 +3228,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3345,7 +3353,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3357,6 +3366,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3477,6 +3487,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/scss/bootstrap/overrides/crm/_button.scss
+++ b/scss/bootstrap/overrides/crm/_button.scss
@@ -12,12 +12,9 @@
 .crm-button-type-cancel,
 .crm-button-type-delete {
   border-color: $gray-light;
+  color: $gray-darker !important;
 
-  input {
-    color: $gray-darker !important;
-  }
-
-  input:hover {
+  &:hover {
     color: $gray-dark !important;
   }
 }

--- a/scss/civicrm/administer/civi-case/_case-types.scss
+++ b/scss/civicrm/administer/civi-case/_case-types.scss
@@ -41,6 +41,28 @@
         }
       }
     }
+
+    .crm-button {
+      @extend %btn-civi;
+
+      &[crm-icon=fa-check] {
+        @extend %btn-civi-primary;
+        padding: 8px 19px;
+      }
+
+      &[crm-icon=fa-times] {
+        @extend %btn-civi-secondary-outline;
+        border: solid 1px $gray-dark;
+        color: $gray;
+        margin: 0;
+        padding: 7px 19px;
+
+        &:hover {
+          background: $gray-dark;
+          color: $crm-white;
+        }
+      }
+    }
   }
 
   table tr.forked {

--- a/scss/civicrm/administer/common/_common.scss
+++ b/scss/civicrm/administer/common/_common.scss
@@ -59,28 +59,6 @@ ul.civihr-popup {
         margin-right: 0;
       }
     }
-
-    .crm-button {
-      @extend %btn-civi;
-
-      &[crm-icon=fa-check] {
-        @extend %btn-civi-primary;
-        padding: 8px 19px;
-      }
-
-      &[crm-icon=fa-times] {
-        @extend %btn-civi-secondary-outline;
-        border: solid 1px $gray-dark;
-        color: $gray;
-        margin: 0;
-        padding: 7px 19px;
-
-        &:hover {
-          background: $gray-dark;
-          color: $crm-white;
-        }
-      }
-    }
   }
 
   .action-link {

--- a/scss/civicrm/administer/contribute/_managepremiums.scss
+++ b/scss/civicrm/administer/contribute/_managepremiums.scss
@@ -20,14 +20,15 @@
       }
 
       .premium-full-disabled {
-        input[type='button'] {
+        button {
+          background: darken($crm-copy, $crm-darken-percentage);
           margin: 20px 0;
         }
       }
 
       .crm-contribution-manage_premiums-form-block {
         padding: 0;
-        
+
         .collapsible-title {
           margin-bottom: 0;
         }

--- a/scss/civicrm/administer/display/_display.scss
+++ b/scss/civicrm/administer/display/_display.scss
@@ -73,13 +73,8 @@
         padding: 0;
       }
 
-      .crm-i {
-        margin: 0 -25px 0 15px !important;
-      }
-
       #ckeditor_config {
-        margin: 0 !important;
-        padding-left: 30px;
+        padding: 8px 12px;
       }
     }
   }

--- a/scss/civicrm/common/_buttons.scss
+++ b/scss/civicrm/common/_buttons.scss
@@ -56,10 +56,11 @@ $button-border-radius: 2px;
     }
   }
 
-  input.crm-form-submit {
+  button.crm-form-submit {
     background: $brand-primary;
     border-color: $brand-primary;
     border-radius: $border-radius-base;
+    box-sizing: content-box;
     font-family: $font-family-base;
     margin-right: 0;
     padding: 8px 12px;
@@ -102,7 +103,7 @@ $button-border-radius: 2px;
       }
     }
 
-    input.crm-form-submit {
+    button.crm-form-submit {
       color: $crm-cancel-color !important;
 
       &:hover {
@@ -151,15 +152,12 @@ $button-border-radius: 2px;
 
       .crm-button-type-cancel,
       .crm-button-type-back {
-        input {
-          border: solid 1px $gray-dark;
-          ///The default theme uses "!important"
-          color: $crm-cancel-color !important;
+        border: solid 1px $gray-dark;
+        color: $crm-cancel-color !important; // The default theme uses "!important"
 
-          &:hover {
-            background: darken($crm-copy, $crm-darken-percentage);
-            color: $crm-white !important;
-          }
+        &:hover {
+          background: darken($crm-copy, $crm-darken-percentage);
+          color: $crm-white !important;
         }
       }
     }
@@ -178,8 +176,8 @@ $button-border-radius: 2px;
     line-height: 35px;
   }
 
-  #crm-submit-buttons input.crm-form-submit,
-  .crm-button input.crm-form-submit,
+  #crm-submit-buttons button.crm-form-submit,
+  button.crm-button.crm-form-submit,
   .crm-hover-button,
   .ui-dialog-buttonset .ui-button,
   a.button,
@@ -254,15 +252,13 @@ $button-border-radius: 2px;
     .crm-i {
       background-color: transparent !important;
       color: $crm-white;
-      padding: 2px 3px;
-      top: 0;
+      padding: 0 2px;
     }
   }
 
   .crm-i {
     line-height: inherit;
     text-shadow: none;
-    vertical-align: middle;
   }
 
   .crm-button-type-refresh {
@@ -381,8 +377,9 @@ button {
   border: 0;
   border-radius: $border-radius-base;
   color: $crm-white;
+  cursor: pointer;
   font-family: $font-family-base;
-  line-height: 1;
+  line-height: $line-height-base;
   padding: 11px 12px;
   text-shadow: none;
   text-transform: uppercase;

--- a/scss/civicrm/contact/pages/_contributions.scss
+++ b/scss/civicrm/contact/pages/_contributions.scss
@@ -1015,7 +1015,7 @@ form.CRM_Contribute_Form_ContributionCharts {
 
     button.crm-form-submit {
       margin-left: 5px;
-      padding: 8px 11px;
+      padding: 4px 10px;
       text-shadow: none;
       vertical-align: middle;
     }

--- a/scss/civicrm/contact/pages/_contributions.scss
+++ b/scss/civicrm/contact/pages/_contributions.scss
@@ -1013,9 +1013,9 @@ form.CRM_Contribute_Form_ContributionCharts {
   .form-layout-compressed {
     margin: 20px 0 0;
 
-    input.crm-form-submit {
+    button.crm-form-submit {
       margin-left: 5px;
-      padding: 4px 10px;
+      padding: 8px 11px;
       text-shadow: none;
       vertical-align: middle;
     }

--- a/scss/civicrm/financial/_batchtransaction.scss
+++ b/scss/civicrm/financial/_batchtransaction.scss
@@ -23,7 +23,7 @@
     }
 
     .form-layout-compressed {
-      input.crm-form-submit {
+      button.crm-form-submit {
         margin-left: 5px;
         padding: 4px 10px;
         vertical-align: middle;

--- a/scss/civicrm/search/pages/_advanced-search.scss
+++ b/scss/civicrm/search/pages/_advanced-search.scss
@@ -6,13 +6,9 @@
   }
 
   .form-layout {
-    .crm-i-button {
+    .crm-form-submit {
       margin-left: 20px;
       margin-top: 15px;
-
-      .crm-i { /* stylelint-disable-line selector-max-compound-selectors */
-        top: -2px;
-      }
     }
   }
 }

--- a/scss/civicrm/search/pages/_full-text-search.scss
+++ b/scss/civicrm/search/pages/_full-text-search.scss
@@ -4,8 +4,9 @@
   td {
     button.crm-form-submit {
       @extend .btn-sm;
+      float: none;
       margin-left: 20px !important;
-      margin-top: -8px;
+      vertical-align: initial;
     }
   }
 

--- a/scss/civicrm/search/pages/_full-text-search.scss
+++ b/scss/civicrm/search/pages/_full-text-search.scss
@@ -2,9 +2,10 @@
 
 .CRM_Contact_Form_Search_Custom .crm-search-form-block table.form-layout-compressed {
   td {
-    input.crm-form-submit {
+    button.crm-form-submit {
       @extend .btn-sm;
       margin-left: 20px !important;
+      margin-top: -8px;
     }
   }
 


### PR DESCRIPTION
## Overview
Recently in the Civicrm Core(https://github.com/civicrm/civicrm-core/pull/18410), all the `input` type button markups has been changed to `button` elements. This caused a lot of styles to break when using Shoreditch theme. So this PR fixes those UI related style issues.

## Before (Only showing some examples)
![2020-10-19 at 3 08 PM](https://user-images.githubusercontent.com/5058867/96428097-027c8a80-121d-11eb-8f76-b0674d854c75.png)

![2020-10-19 at 3 09 PM](https://user-images.githubusercontent.com/5058867/96428198-1922e180-121d-11eb-854a-8129b0837262.png)

![2020-10-19 at 3 10 PM](https://user-images.githubusercontent.com/5058867/96428340-48d1e980-121d-11eb-8468-fcbb76a41e7f.png)

## After (Only showing some examples)
![2020-10-19 at 3 12 PM](https://user-images.githubusercontent.com/5058867/96428566-89316780-121d-11eb-8834-440e9497882f.png)

![2020-10-19 at 3 12 PM](https://user-images.githubusercontent.com/5058867/96428522-7c147880-121d-11eb-9ebc-fd5910b81084.png)

![2020-10-19 at 3 11 PM](https://user-images.githubusercontent.com/5058867/96428489-70c14d00-121d-11eb-94a7-83eb5aee3f8a.png)


## Technical Details
1. Changed css selector from `input` to `button` in
```
scss/civicrm/administer/contribute/_managepremiums.scss
scss/civicrm/common/_buttons.scss
scss/civicrm/contact/pages/_contributions.scss
scss/civicrm/financial/_batchtransaction.scss
scss/civicrm/search/pages/_full-text-search.scss
```

2. Made adjustments to the following files to support new markup
```
// There are no extra parent divs for buttons, so moved the css one level up
scss/bootstrap/overrides/crm/_button.scss 

// no extra css required for .crm-i, as items inside buttons are auto aligned
scss/civicrm/administer/display/_display.scss 

// styles for .crm-i removed, as items inside buttons are auto aligned, and crm-i-button does not exist anymore
scss/civicrm/search/pages/_advanced-search.scss 
```

3. Added styles specific to Case Types page in `scss/civicrm/administer/civi-case/_case-types.scss`. And this code was moved from `scss/civicrm/administer/common/_common.scss `. 
This style was moved to the `common.scss` in https://github.com/civicrm/org.civicrm.shoreditch/pull/49. But now it is causing regressions in other pages. And other pages are working fine without these changes, so made it only for case type page.

## Comments
Backstop JS and manual test suites were run to ensure no regressions are present.