### PR TITLE
fix console error for extended reports

### DIFF
--- a/js/add-missing-date-addons.js
+++ b/js/add-missing-date-addons.js
@@ -12,8 +12,10 @@ CRM.$(function () {
    * @param {Object} input The jQuery object for the input
    */
   function addDateAddonToInput (input) {
-    var placeholderWithoutCalendar = input.attr('placeholder').replace('', '');
-
+    if (input.attr('placeholder')) {
+      var placeholderWithoutCalendar = input.attr('placeholder').replace('', '');
+    }
+    
     CRM.$('<span class="addon fa fa-calendar"></span>')
       .insertAfter(input)
       .css('margin-top', input.css('margin-top'))


### PR DESCRIPTION
Get this error on extended reports in combination with shoreditch
```
11:28:42.212 add-missing-date-addons.js?qnvpbs:15 Uncaught TypeError: Cannot read property 'replace' of undefined
    at addDateAddonToInput (add-missing-date-addons.js?qnvpbs:15)
    at HTMLInputElement.<anonymous> (add-missing-date-addons.js?qnvpbs:50)
    at Function.each (jquery.js?qnvpbs:371)
    at jQuery.fn.init.each (jquery.js?qnvpbs:137)
    at MutationObserver.<anonymous> (add-missing-date-addons.js?qnvpbs:46)
    at add-missing-date-addons.js?qnvpbs:69
addDateAddonToInput @ add-missing-date-addons.js?qnvpbs:15
(anonymous) @ add-missing-date-addons.js?qnvpbs:50
each @ jquery.js?qnvpbs:371
each @ jquery.js?qnvpbs:137
(anonymous) @ add-missing-date-addons.js?qnvpbs:46
(anonymous) @ add-missing-date-addons.js?qnvpbs:69
setTimeout (async)
(anonymous) @ add-missing-date-addons.js?qnvpbs:68
childList (async)
(anonymous) @ jquery-1.7.1.min.js:3
domManip @ jquery-1.7.1.min.js:4
append @ jquery-1.7.1.min.js:3
(anonymous) @ ip.js:16
sendResponseAndClearCallback @ VM934 extensions::messaging:419
messageListener @ VM934 extensions::messaging:451
EventImpl.dispatchToListener @ VM927 extensions::event_bindings:403
publicClassPrototype.(anonymous function) @ VM933 extensions::utils:138
EventImpl.dispatch_ @ VM927 extensions::event_bindings:387
EventImpl.dispatch @ VM927 extensions::event_bindings:409
publicClassPrototype.(anonymous function) @ VM933 extensions::utils:138
dispatchOnMessage @ VM934 extensions::messaging:392
```

![extended_report](https://user-images.githubusercontent.com/3455173/107606551-5b3dbc00-6c2e-11eb-82d3-b02e79a8fce0.png)
