### PR TITLE
CPS-480: Fix broken buttons

### DIFF
--- a/scss/bootstrap/overrides/crm/_button.scss
+++ b/scss/bootstrap/overrides/crm/_button.scss
@@ -1,7 +1,5 @@
 // Makes next and upload buttons look like primary buttons:
-.crm-button-type-next,
-.crm-button-type-upload {
-
+.crm-button-type-next {
   @include button-outline-variant(white, $brand-primary);
 
   .crm-i { display: none; }

--- a/scss/civicrm/common/_buttons.scss
+++ b/scss/civicrm/common/_buttons.scss
@@ -61,12 +61,12 @@ $button-border-radius: 2px;
     border-color: $brand-primary;
     border-radius: $border-radius-base;
     box-sizing: content-box;
-    color: $crm-white !important;
+    color: $crm-white;
     font-family: $font-family-base;
     margin-right: 0;
     padding: 8px 12px;
     text-shadow: none;
-    text-transform: uppercase !important;
+    text-transform: uppercase;
 
     &:not(:last-child) {
       margin-right: 10px;
@@ -171,8 +171,6 @@ $button-border-radius: 2px;
 
   .crm-button {
     background: none;
-    color: $crm-white !important;
-    text-transform: uppercase !important;
   }
 
   table.form-layout > tbody > tr > td > span.crm-button.crm-i-button {
@@ -429,4 +427,11 @@ button {
   > .crm-i {
     margin-top: 7px;
   }
+}
+
+// Ensure these components look well in conjunction with Bootstrap:
+#bootstrap-theme .crm-form-submit,
+#bootstrap-theme .crm-button {
+  color: $crm-white;
+  text-transform: uppercase;
 }

--- a/scss/civicrm/common/_buttons.scss
+++ b/scss/civicrm/common/_buttons.scss
@@ -61,11 +61,12 @@ $button-border-radius: 2px;
     border-color: $brand-primary;
     border-radius: $border-radius-base;
     box-sizing: content-box;
+    color: $crm-white !important;
     font-family: $font-family-base;
     margin-right: 0;
     padding: 8px 12px;
     text-shadow: none;
-    text-transform: uppercase;
+    text-transform: uppercase !important;
 
     &:not(:last-child) {
       margin-right: 10px;
@@ -170,6 +171,8 @@ $button-border-radius: 2px;
 
   .crm-button {
     background: none;
+    color: $crm-white !important;
+    text-transform: uppercase !important;
   }
 
   table.form-layout > tbody > tr > td > span.crm-button.crm-i-button {

--- a/scss/civicrm/common/_buttons.scss
+++ b/scss/civicrm/common/_buttons.scss
@@ -435,3 +435,7 @@ button {
   color: $crm-white;
   text-transform: uppercase;
 }
+
+#bootstrap-theme .crm-button:not(:last-child) {
+  margin-right: $crm-gap-small * 2;
+}


### PR DESCRIPTION
## Overview

This PR fixes an issue where CiviCRM buttons inside of Bootstrap templates break.

## Before & After

### CRM buttons
#### Before
![pr](https://user-images.githubusercontent.com/1642119/110425228-642d7c00-807a-11eb-8726-45d944ea03f7.gif)

#### After
![pr](https://user-images.githubusercontent.com/1642119/110537559-3b000080-80f9-11eb-9bbb-d05c2b673178.gif)

#### Technical details

All `.crm-button` and `.crm-form-submit` buttons inside of `#bootstrap-theme` would have their style overridden by a `color: inherit` https://github.com/civicrm/org.civicrm.shoreditch/commit/f3e73beeefa5cce3a1caf73e6a6166229749720d#diff-293f309d5b967b2ce90466201daefdeaad764020a635e624f1ac6b19d225fb2bR257 and `text-transform: none` https://github.com/civicrm/org.civicrm.shoreditch/commit/f3e73beeefa5cce3a1caf73e6a6166229749720d#diff-293f309d5b967b2ce90466201daefdeaad764020a635e624f1ac6b19d225fb2bR279 that should be applied to bootstrap buttons. To avoid this, we overrode the definitions for `.crm-button` and `.crm-form-submit` by adding an `!important` to their color and text transform properties. This way Bootstrap can't replace these properties for these buttons.

### Upload buttons

#### Before
![pr](https://user-images.githubusercontent.com/1642119/110425171-4cee8e80-807a-11eb-87f6-4bf267e52029.gif)

#### After
![pr](https://user-images.githubusercontent.com/1642119/110424940-f719e680-8079-11eb-915d-2c3f25203c64.gif)

#### Technical details

Upload buttons are submit buttons used in forms, not necessarily for uploading files. These need to look like any other button. Previously we defined these upload buttons as outlines:
https://github.com/civicrm/org.civicrm.shoreditch/commit/e948807afe6732c947a6a1b7456ecd59c09bad52#diff-d70c310903cd4caf4066146aa6a16294bb25f009a7f6a7f7b85d63c494525f3dR1-R7
The reason for this is not clear (since the file history is not complete) and the `// Makes next and upload buttons look like primary buttons:` comment is not clear since `button-outline-variant` displays outlined buttons, not primary buttons. We have only removed this from the upload buttons, but need to investigate "next" buttons to confirm if the style is right for them.

## Backstop Report:

https://github.com/compucorp/backstopjs-config/actions/runs/636368203

Some artifacts were found, but manually confirmed that no actual regressions were introduced.

