### PR TITLE
Fix buttons that are showing up with white background on front end

### DIFF
--- a/scss/civicrm/common/_buttons.scss
+++ b/scss/civicrm/common/_buttons.scss
@@ -169,7 +169,7 @@ $button-border-radius: 2px;
   }
 
   .crm-button {
-    background: none;
+    background: $brand-primary;
   }
 
   table.form-layout > tbody > tr > td > span.crm-button.crm-i-button {


### PR DESCRIPTION
The later crm-button class background: none was taking precedence over crm-form-submit class background for submit buttons on contribution and event pages. Now these buttons have background: $brand-primary. This is on 5.35 with Shoreditch beta4.