### PR TITLE
MAE-493: Style the form buttons and Direct Debit batch form actions

### DIFF
--- a/scss/civicrm/common/_buttons.scss
+++ b/scss/civicrm/common/_buttons.scss
@@ -56,6 +56,7 @@ $button-border-radius: 2px;
     }
   }
 
+  button.crm-form-xbutton,
   button.crm-form-submit {
     background: $brand-primary;
     border-color: $brand-primary;
@@ -112,6 +113,7 @@ $button-border-radius: 2px;
     }
   }
 
+  .crm-form-xbutton,
   .crm-submit-buttons {
     height: auto;
     margin: 0;

--- a/scss/civicrm/common/_buttons.scss
+++ b/scss/civicrm/common/_buttons.scss
@@ -113,6 +113,12 @@ $button-border-radius: 2px;
     }
   }
 
+  .crm-form-select {
+    + .crm-button {
+      float: none;
+    }
+  }
+
   .crm-form-xbutton,
   .crm-submit-buttons {
     height: auto;


### PR DESCRIPTION
## Overview
In the latest CiviCRM update(5.35), there were new button classes were updated and hence introduced some UI impairments on the Direct Debit Batch pages. This PR fixes that.

## Before
<img width="1101" alt="Screenshot 2021-03-16 at 12 24 11 PM" src="https://user-images.githubusercontent.com/3340537/111267884-962e7780-8652-11eb-92ba-931c25376626.png">

## After
<img width="1651" alt="Screenshot 2021-03-15 at 7 49 43 PM" src="https://user-images.githubusercontent.com/3340537/111266998-57e48880-8651-11eb-9355-e77e499c6564.png">

## Technical Details
* The action button on the Direct Debit wasn't using `crm-form-submit` class and hence the styles were broken. To fix this, we add `button.crm-form-xbutton` CSS selector to `button.crm-form-submit` CSS selector styles
* The `Go` button was having `.crm-button` class and hence the `float:left` property was getting applied to it. To fix this we reset the floats on the CRM buttons which just appear after the `.crm-form-select`

## Tests
Link to the Github action workflow for running backstop tests - https://github.com/compucorp/backstopjs-config/actions/runs/657199439
- 9 scenarios failed - All are false alarms except `Search Results - Add to Group Modal - more actions `,as the same issue happened for batch page is being fixed here
![issue-backstop](https://user-images.githubusercontent.com/3340537/111427702-7fecee00-871c-11eb-80e5-ae50d565e133.gif)

#### List of failed scenario
* Civicase - Dashboard 
* Civicase - View case activity 
* Civicase - Case Time Spent Report - Grouping 
* Contributions - Manage Price Set - Disable Price Fields Set 
* Contributions - Manage Price Set - View and Edit Price Fields Set - Disable price field Modal 
* Contributions - Manage Price Set - View and Edit Price Fields Set - Delete price field Modal 
* Search Results - Add to Group Modal - more actions 
* Search builder 
* Search Builder - Search result 

