### PR TITLE
CPS-481: Fix Button border

### DIFF
--- a/scss/bootstrap/overrides/crm/_button.scss
+++ b/scss/bootstrap/overrides/crm/_button.scss
@@ -9,7 +9,7 @@
 .crm-button-type-back,
 .crm-button-type-cancel,
 .crm-button-type-delete {
-  border-color: $gray-light;
+  border-color: $gray-dark;
   color: $gray-darker !important;
 
   &:hover {


### PR DESCRIPTION
## Overview
The Cancel Button border was wrong when inside Bootstrap. This PR fixes it.

## Before
![2021-03-22 at 2 10 PM](https://user-images.githubusercontent.com/5058867/111962493-5e26a900-8b18-11eb-8ad7-31553d979a49.png)

## After
![2021-03-22 at 2 09 PM](https://user-images.githubusercontent.com/5058867/111962433-4cdd9c80-8b18-11eb-84f1-47e03bcd811a.png)

## Technical details
The button color was applied in https://github.com/civicrm/org.civicrm.shoreditch/commit/e948807afe6732c947a6a1b7456ecd59c09bad52#diff-d70c310903cd4caf4066146aa6a16294bb25f009a7f6a7f7b85d63c494525f3dR12. 
But there is no explanation of why this color was applied and `$gray-dark` is the correct color.

We never saw this before, because before CiviCRM 5.35 changes, there was an extra input element for buttons, and that input element had the correct colors.

Backstop Report: https://github.com/compucorp/backstopjs-config/actions/runs/675356335