### PR TITLE
CPS-515: Fix Dashlet styles

### DIFF
--- a/scss/civicrm/dashboard/_dashboard.scss
+++ b/scss/civicrm/dashboard/_dashboard.scss
@@ -1,7 +1,9 @@
 $dashboard-dashlets-margin: 10px;
 
+@import 'scss/civicrm/dashboard/dashlets/activity-selector';
 @import 'scss/civicrm/dashboard/dashlets/getting-started';
 @import 'scss/civicrm/dashboard/dashlets/news-feed';
+@import 'scss/civicrm/dashboard/dashlets/reports';
 
 .crm-inactive-dashlet-fieldset {
   legend {
@@ -39,6 +41,10 @@ $dashboard-dashlets-margin: 10px;
   .crm-dashlet-content {
     border-radius: 0 0 $border-radius-small $border-radius-small;
     padding: 0;
+
+    .status.no-popup {
+      border: 0;
+    }
   }
 
   .crm-dashlet-header {

--- a/scss/civicrm/dashboard/dashlets/_activity-selector.scss
+++ b/scss/civicrm/dashboard/dashlets/_activity-selector.scss
@@ -1,0 +1,46 @@
+#civicrm-dashboard {
+  .crm-activity-selector-dashlet {
+    display: grid;
+
+    .crm-search_filters-accordion {
+      td:nth-child(3) {
+        min-width: 285px;
+
+        .crm-absolute-date-from label,
+        .crm-absolute-date-to label {
+          display: block;
+        }
+      }
+    }
+
+    .crm-accordion-header {
+      border-bottom: 1px solid $crm-background;
+      color: $gray-darker;
+      font-weight: $crm-font-weight-h1;
+    }
+
+    .dataTables_wrapper {
+      border-radius: 0;
+      box-shadow: none;
+      margin-bottom: 0;
+
+      .crm-datatable-pager-top {
+        border-radius: 0;
+      }
+
+      .crm-datatable-pager-bottom {
+        line-height: 1.5em;
+        padding: 0 15px;
+      }
+
+      .dataTables_paginate .ui-button {
+        padding: 10px;
+      }
+
+      .dataTables_info {
+        padding: 10px 0;
+        width: 49%;
+      }
+    }
+  }
+}

--- a/scss/civicrm/dashboard/dashlets/_reports.scss
+++ b/scss/civicrm/dashboard/dashlets/_reports.scss
@@ -1,0 +1,13 @@
+#civicrm-dashboard .crm-dashlet-content {
+  .CRM_Report_Form_Member_Summary,
+  .crm-report-layoutTable-form-block {
+    @include civicrm-table;
+  }
+
+  .crm-report-layoutTable-form-block {
+    .crm-pager {
+      box-shadow: none;
+      margin: 0;
+    }
+  }
+}


### PR DESCRIPTION
## Overview
Some of the dashlets inside the dashboard were in a broken state, this PR fixes that.

## Before
Report
![2021-03-22 at 4 25 PM](https://user-images.githubusercontent.com/5058867/111979519-2d9c3a80-8b2b-11eb-8ca4-3929404a45f8.png)

Activities
![2021-03-22 at 4 25 PM](https://user-images.githubusercontent.com/5058867/111979563-3bea5680-8b2b-11eb-8314-09a77cb8c6ec.png)

## After
Report
![2021-03-22 at 4 23 PM](https://user-images.githubusercontent.com/5058867/111979387-06456d80-8b2b-11eb-8fb7-7a64053d1f9c.png)

Activities
![2021-03-22 at 4 24 PM](https://user-images.githubusercontent.com/5058867/111979425-13625c80-8b2b-11eb-80f0-12f20b07e32d.png)

## Technical details
This is a regression of https://github.com/civicrm/org.civicrm.shoreditch/pull/495. 
All the existing styles were not moved to the new dashboard. Some of the styles were completely removed.

Backstop Report: As these styles only affect the Dashboard, only manual testing was done. As there is no chance of css leakage.