### PR TITLE
CPS-378: Fix Case Status labels

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Overview
+_A brief description of the pull request. Try to keep it non-technical._
+
+## Before
+_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
+
+## After
+_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
+
+## Technical Details
+_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_
+
+### Core overrides
+_If the PR overrides/patches a core file, then please explain here, for each file:_
+
+1. _Which file it is_
+2. _The reason why it was overridden/patched_
+3. _What the override/patch consists of_
+
+## Comments
+_Anything else you would like the reviewer to note_

--- a/package-lock.json
+++ b/package-lock.json
@@ -3195,6 +3195,15 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
+<<<<<<< HEAD
+=======
+          "dev": true,
+          "optional": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+>>>>>>> fabf2c3e (CPS-378: Fix case status labels)
           "dev": true,
           "optional": true
         },

--- a/scss/civicrm/administer/contribute/_contribute.scss
+++ b/scss/civicrm/administer/contribute/_contribute.scss
@@ -19,6 +19,12 @@
   #alpha-filter {
     border-bottom: 1px solid $crm-grayblue-dark;
   }
+
+  .dataTable {
+    td {
+      background: $crm-white !important;
+    }
+  }
 }
 
 &#{civi-page('admin-contribute')} {
@@ -28,6 +34,12 @@
     #alpha-filter,
     .dataTables_wrapper {
       box-shadow: none;
+    }
+
+    .dataTable {
+      td {
+        background: $crm-white !important;
+      }
     }
   }
 

--- a/scss/civicrm/administer/customize-data/_customize-data.scss
+++ b/scss/civicrm/administer/customize-data/_customize-data.scss
@@ -90,9 +90,13 @@
     box-shadow: none !important;
   }
 
-  .dataTable > tbody > tr > td.crm-custom_option-links {
-    padding-right: 20px;
-    text-align: right;
+  .dataTable > tbody > tr > td {
+    background: $crm-white !important;
+
+    .crm-custom_option-links {
+      padding-right: 20px;
+      text-align: right;
+    }
   }
 
   .ui-dialog-content #field_page {

--- a/scss/civicrm/administer/system-status/_configtask.scss
+++ b/scss/civicrm/administer/system-status/_configtask.scss
@@ -19,6 +19,12 @@
           background: $gray-lighter !important;
         }
       }
+
+      tr:not(.columnheader) {
+        td {
+          background: $crm-white !important;
+        }
+      }
     }
 
     td.tasklist a {

--- a/scss/civicrm/cases/_dashboard.scss
+++ b/scss/civicrm/cases/_dashboard.scss
@@ -81,6 +81,12 @@
     .spacer {
       height: 20px;
     }
+
+    .dataTable {
+      td {
+        background: $crm-white !important;
+      }
+    }
   }
 
   div[class*='crm-case-filter-'] {

--- a/scss/civicrm/common/_tables.scss
+++ b/scss/civicrm/common/_tables.scss
@@ -103,7 +103,7 @@ table {
   }
 
   td {
-    background: $crm-white !important;
+    background: $crm-white;
 
     &.label {
       vertical-align: middle !important;

--- a/scss/civicrm/contact/pages/_events.scss
+++ b/scss/civicrm/contact/pages/_events.scss
@@ -101,6 +101,7 @@
 
     tbody tr {
       td {
+        background: $crm-white !important;
         line-height: normal;
         padding: 10px;
 

--- a/scss/civicrm/contact/pages/_reports.scss
+++ b/scss/civicrm/contact/pages/_reports.scss
@@ -12,6 +12,7 @@ body[class*='page-civicrm-report-'] {
 
     table.report-layout {
       td {
+        background: $crm-white !important;
         border-bottom: 1px solid $gray-light;
 
         &.report-contents-right {


### PR DESCRIPTION
## Overview
When the Case Status had a Dark Colored background in the Option Settings, the Case Status label were shown as white text on white background, this PR fixes that problem.

## Before
![2021-03-30 at 3 51 PM](https://user-images.githubusercontent.com/5058867/112974228-db34cc80-916f-11eb-8900-c99a5267507e.png)

## After
![2021-03-30 at 3 51 PM](https://user-images.githubusercontent.com/5058867/112974184-cd7f4700-916f-11eb-8550-33bd6fe50539.png)

## Technical Details
The Background Color of Case Status label should ideally be same as the color set in Option Settings.
But in `scss/civicrm/common/_tables.scss`, the Background was forced to Color White using `!important`, and that ignored the inline background color styles.
Now `!important` is removed, and individual styles are tables to tables where this White Background needs to be forced.

## Comments
Backstop Tests are done in https://github.com/compucorp/backstopjs-config/actions/runs/700673399