### PR TITLE
MAE-511: Fix the alignment on new mailing page

### DIFF
--- a/scss/civicrm/contact/pages/_email-builder.scss
+++ b/scss/civicrm/contact/pages/_email-builder.scss
@@ -29,6 +29,13 @@
     }
   }
 
+  .crmMailing-preview {
+    .crm-button {
+      display: inline-block;
+      float: none;
+    }
+  }
+
   .label {
     text-align: left;
 

--- a/scss/civicrm/contact/pages/_email-builder.scss
+++ b/scss/civicrm/contact/pages/_email-builder.scss
@@ -30,10 +30,32 @@
   }
 
   .crmMailing-preview {
+    display: flex;
+
+    .preview-group,
+    .preview-popup,
+    .preview-contact {
+      height: auto;
+    }
+
+    .preview-popup {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+    }
+
     .crm-button {
       display: inline-block;
       float: none;
+      margin-right: 0;
+      margin-top: $crm-standard-gap;
     }
+  }
+
+  .crm-wizard-buttons {
+    @include clearfix();
+
+    padding: $crm-standard-gap;
   }
 
   .label {


### PR DESCRIPTION
## Overview
The preview button alignment was broken on the new mailing page for CiviCRM version 5.35.1. This PR fixes the button alignment on the New mailing page.

## Before
<img width="914" alt="Screenshot 2021-03-30 at 7 50 53 PM" src="https://user-images.githubusercontent.com/3340537/113006127-b9990c80-9192-11eb-8755-85a633d8589a.png">

## After
<img width="714" alt="Screenshot 2021-03-30 at 7 53 39 PM" src="https://user-images.githubusercontent.com/3340537/113006281-d9303500-9192-11eb-9f23-397378306c5c.png">

## Technical Details
* Mailing preview button alignment was broken because CiviCRM 5.35.1 introduces extra `display` and `float` styles to `.crm-button` inside the `.civicrm-container`. See [this](https://github.com/civicrm/civicrm-core/blob/5.35.1/css/civicrm.css#L1893-L1894)
* To fix this we reset these values in the shoreditch custom overrides.

## Tests
Backstop test run can be found at https://github.com/compucorp/backstopjs-config/actions/runs/701788475 

### Failed screens (14) 
* Civicase - View case activity - False alarm
* Civicase - Case Time Spent Report - Grouping  - False alarm
* Find Contributions - Results - False alarm
* Find Contributions - Show Individual Payments - Results - False alarm
* Contributions - Premiums Pages - disable Premium Modal - results - False alarm
* Contributions - Manage Price Set - Disable Price Fields Set - False alarm
* Contributions - Manage Price Set - View and Edit Price Fields Set - Delete price field Modal - False alarm
* New Mailings - Fixed screen
* New Mailings - Attachments - Fixed screen
* New Mailings - Header and Footer - Fixed screen
* New Mailings - Publication - Fixed screen
* New Mailings - Responses - Fixed screen
* New Mailings - Tracking - Fixed screen
* Email - schedule/send via CiviMail - Fixed screen

## Update
As a part of this PR, the preview section and action links footer spacing has been fixed. This PR also adds suitable styles for the spacing consistency of the preview footer.
### Before
<img width="1662" alt="Screenshot 2021-03-31 at 4 56 55 PM" src="https://user-images.githubusercontent.com/3340537/113142588-ae081d00-9248-11eb-9eec-777aaafe88d2.png">

### After
<img width="1628" alt="Screenshot 2021-03-31 at 4 55 53 PM" src="https://user-images.githubusercontent.com/3340537/113142599-b2343a80-9248-11eb-87b0-a81d8f79f04b.png">

### Technical Details
* Add basic spacing to the preview accordion body elements 
* Add clearfix to the action items so that the container's background is visible and then added basic spacing.

### Tests
Backstop JS test suite workflow - https://github.com/compucorp/backstopjs-config/actions/runs/704919272
A new screen `New A/B` test is also fixed as part of these changes
#### Before
<img width="1667" alt="Screenshot 2021-04-01 at 11 40 12 AM" src="https://user-images.githubusercontent.com/3340537/113251042-3afdb580-92df-11eb-881e-2aceb5d418f3.png">

#### After
<img width="1651" alt="Screenshot 2021-04-01 at 11 40 20 AM" src="https://user-images.githubusercontent.com/3340537/113251049-3f29d300-92df-11eb-8ba4-872c8a2832df.png">

### Failed screens (15)
* Civicase - View case activity - False alarm
* Civicase - Case Time Spent Report - Grouping  - False alarm
* Find Contributions - Results - False alarm
* Find Contributions - Show Individual Payments - Results - False alarm
* Contributions - Premiums Pages - disable Premium Modal - results - False alarm
* Contributions - Manage Price Set - Disable Price Fields Set - False alarm
* Contributions - Manage Price Set - View and Edit Price Fields Set - Delete price field Modal - False alarm
* New Mailings - Fixed screen
* New Mailings - Attachments - Fixed screen
* New Mailings - Header and Footer - Fixed screen
* New Mailings - Publication - Fixed screen
* New Mailings - Responses - Fixed screen
* New Mailings - Tracking - Fixed screen
* Email - schedule/send via CiviMail - Fixed screen
* New A/B test - Fixed screen