### PR TITLE
RSESPRT-33: Fix Next Button

### DIFF
--- a/scss/bootstrap/overrides/crm/_button.scss
+++ b/scss/bootstrap/overrides/crm/_button.scss
@@ -1,7 +1,5 @@
 // Makes next and upload buttons look like primary buttons:
 .crm-button-type-next {
-  @include button-outline-variant(white, $brand-primary);
-
   .crm-i { display: none; }
 }
 


### PR DESCRIPTION
## Overview
Similar to https://github.com/civicrm/org.civicrm.shoreditch/pull/492.
This PR removes the override made for `.crm-button-type-next` button.

## Before
![2021-04-12 at 3 51 PM](https://user-images.githubusercontent.com/5058867/114379864-fc9dab80-9ba6-11eb-9819-919f05412e00.png)

## After
![2021-04-12 at 3 51 PM](https://user-images.githubusercontent.com/5058867/114379838-f1e31680-9ba6-11eb-9046-b0b7d92270ef.png)

## Backstop Tests
CiviCase - https://github.com/compucorp/uk.co.compucorp.civicase/actions/runs/740312390
CiviCRM - https://github.com/compucorp/backstopjs-config/actions/runs/740130703