### PR TITLE
RSE-1609: Fix help icon

### DIFF
--- a/scss/civicrm/common/_accordions.scss
+++ b/scss/civicrm/common/_accordions.scss
@@ -31,11 +31,12 @@
   }
 
   .helpicon {
-    color: $brand-primary;
+    color: $crm-white;
     opacity: 1;
     padding-left: 15px;
 
     &:hover {
+      color: $crm-white;
       opacity: 0.8;
     }
   }


### PR DESCRIPTION
## Overview
Fixed the `helpicon` font color when inside a CRM Accordion Header element.

## Before
![before](https://user-images.githubusercontent.com/5058867/114516384-f832ca80-9c5a-11eb-8d48-329923817c84.gif)

## After
![fater](https://user-images.githubusercontent.com/5058867/114516280-de918300-9c5a-11eb-93f4-46f8937c7b32.gif)

## Technical Details
In https://github.com/civicrm/org.civicrm.shoreditch/pull/35/files#diff-80b1b289804999801a1c94d7aa7c41802b4047cded601b06fd2846ff1c75614eR46, the font color was set to `$brand-primary;`, but it was clearly wrong. Because in Blue Background, blue font wont be visible. So changed it to white.

Backstop Tests - https://github.com/compucorp/backstopjs-config/actions/runs/743927816
