### PR TITLE
ACUSPRT-81: Add FontAwesome inside custom-civicrm.scss

### DIFF
--- a/scss/civicrm/custom-civicrm.scss
+++ b/scss/civicrm/custom-civicrm.scss
@@ -1,13 +1,12 @@
 @import 'civicrm/variables';
 @import 'civicrm/functions';
 @import 'civicrm/mixins';
+@import 'bootstrap/vendor/font-awesome/font-awesome';
 @import 'bootstrap/overrides/variables';
 @import 'base/scss/vendor/bootstrap/variables';
 @import 'base/scss/vendor/bootstrap/mixins/**/*';
 @import 'bootstrap/mixins/**/*';
 @import 'bootstrap/fonts/**/*';
-@import 'bootstrap/vendor/font-awesome/variables';
-@import 'bootstrap/vendor/font-awesome/path';
 @import 'bootstrap/overrides/style/**/*';
 @import 'angular/overrides/**/*';
 @import 'jquery/overrides/**/*';


### PR DESCRIPTION
## Overview
Shoreditch uses FontAwesome v4. But if Drupal loads Font Awesome v5, then all the icons in CiviCRM does not work anymore. This PR fixes the same.

## Before
![2021-04-14 at 3 30 PM](https://user-images.githubusercontent.com/5058867/114692614-66988b00-9d36-11eb-994e-91f6a18c1120.png)

## After
![2021-04-14 at 3 29 PM](https://user-images.githubusercontent.com/5058867/114692466-449f0880-9d36-11eb-80a0-d20f3c3294ff.png)

## Technical Details
FontAwesome v4 works fine when used inside `$bootstrap-theme`, because of https://github.com/civicrm/org.civicrm.shoreditch/blob/a3c253a0ec40e7aae78e93d90a6915270d5a9a4e/scss/bootstrap/bootstrap.scss#L2. As it embeds the whole FontAwesome v4 inside `$bootstrap-theme` namespace.

But the same was not true when used outside of `$bootstrap-theme`. Because in https://github.com/civicrm/org.civicrm.shoreditch/blob/c9c7bb646a726a461676011d2c9a41cffd6208a9/scss/civicrm/custom-civicrm.scss#L9-L10, only the Variables and Paths were added.

Now added `@import 'bootstrap/vendor/font-awesome/font-awesome';` inside `scss/civicrm/custom-civicrm.scss`, so that Shoreditch icons work everywhere without being affected by Drupal.

## Backstop JS Tests
CiviCRM Core - https://github.com/compucorp/backstopjs-config/actions/runs/747821192
CiviCase - https://github.com/compucorp/uk.co.compucorp.civicase/actions/runs/747951414