### PR TITLE
RSE-1608: Adjust style for export dialog

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,12 +10,7 @@ _What has been changed. Please provide screenshots or gifs ([LICEcap](http://www
 ## Technical Details
 _If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_
 
-### Core overrides
-_If the PR overrides/patches a core file, then please explain here, for each file:_
-
-1. _Which file it is_
-2. _The reason why it was overridden/patched_
-3. _What the override/patch consists of_
-
+## Backstop JS Report
+_Attaching Backstop JS test report is must for every Pull Request. Run BackstopJS tests from https://github.com/compucorp/backstopjs-config/actions/workflows/backstop.yml, and attach a link to the workflow run_
 ## Comments
 _Anything else you would like the reviewer to note_

--- a/scss/civicrm/contact/pages/_export.scss
+++ b/scss/civicrm/contact/pages/_export.scss
@@ -148,6 +148,8 @@
 }
 
 .crm-export-ui-save-mapping-dialog {
+  $export-form-label-width: 190px;
+
   &.ui-dialog-content.ui-widget-content {
     padding: 0;
   }
@@ -155,17 +157,17 @@
   .crm-form-block {
     box-shadow: none;
     margin-bottom: 0;
-    padding: 20px;
+    padding: $panel-body-padding;
 
     label {
       display: inline-block;
-      width: 190px;
+      width: $export-form-label-width;
     }
   }
 
   .ui-dialog-buttonpane.ui-widget-content {
     height: auto;
-    padding: $modal-inner-padding ($modal-inner-padding * 2);
+    padding: $modal-inner-padding;
     position: inherit;
     width: auto;
 

--- a/scss/civicrm/contact/pages/_export.scss
+++ b/scss/civicrm/contact/pages/_export.scss
@@ -146,3 +146,35 @@
     }
   }
 }
+
+.crm-export-ui-save-mapping-dialog {
+  &.ui-dialog-content.ui-widget-content {
+    padding: 0;
+  }
+
+  .crm-form-block {
+    box-shadow: none;
+    margin-bottom: 0;
+    padding: 20px;
+  }
+
+  .ui-dialog-buttonpane.ui-widget-content {
+    height: auto;
+    padding: 15px 30px;
+    position: inherit;
+    width: auto;
+
+    .crm-button {
+      background: $brand-primary;
+      border-radius: 0;
+
+      &:hover {
+        background: darken($brand-primary, $crm-darken-percentage);
+      }
+    }
+  }
+
+  .crm-marker {
+    margin-right: 0;
+  }
+}

--- a/scss/civicrm/contact/pages/_export.scss
+++ b/scss/civicrm/contact/pages/_export.scss
@@ -156,6 +156,11 @@
     box-shadow: none;
     margin-bottom: 0;
     padding: 20px;
+
+    label {
+      display: inline-block;
+      width: 190px;
+    }
   }
 
   .ui-dialog-buttonpane.ui-widget-content {

--- a/scss/civicrm/contact/pages/_export.scss
+++ b/scss/civicrm/contact/pages/_export.scss
@@ -165,7 +165,7 @@
 
   .ui-dialog-buttonpane.ui-widget-content {
     height: auto;
-    padding: 15px 30px;
+    padding: $modal-inner-padding ($modal-inner-padding * 2);
     position: inherit;
     width: auto;
 


### PR DESCRIPTION
## Overview
This PR fixes the style of the form for saving a set of fields after a contact export action.


## Before
On the `Export Options` tab, choosing "Select fields for export":
![image](https://user-images.githubusercontent.com/74304572/119526540-adec4f80-bda9-11eb-9ef7-80efb1bb492b.png)

We are moved to select the required fields. Then, the dialog presented there has the "Save fields " button disabled and almost no visible:
![image](https://user-images.githubusercontent.com/74304572/119527088-30750f00-bdaa-11eb-9a95-7436b7dc36f0.png)
even after entering text on the input:
![image](https://user-images.githubusercontent.com/74304572/119527160-44b90c00-bdaa-11eb-8e9b-d795f635e9de.png)


## After
The button on the dialog window is visible, presenting an appropriate disabled style:
![image](https://user-images.githubusercontent.com/74304572/119822164-8c13d980-bf1d-11eb-9977-3bf3071511c8.png)
After entering text on the input, the disabled style is removed:
![image](https://user-images.githubusercontent.com/74304572/119822186-9209ba80-bf1d-11eb-9e06-393a0bf15835.png)
And also, a hover effect was added:
![image](https://user-images.githubusercontent.com/74304572/119822230-9afa8c00-bf1d-11eb-8eae-50b892f098df.png)

## Technical Details
Backstop Tests: https://github.com/compucorp/backstopjs-config/actions/runs/906013759