### PR TITLE
ASESPRT-405: Break long "Location Type" name strings

### DIFF
--- a/scss/civicrm/contact/_detail.scss
+++ b/scss/civicrm/contact/_detail.scss
@@ -51,6 +51,7 @@
   div.crm-summary-row {
     div.crm-label {
       font-weight: $crm-font-weight-bold;
+      word-break: break-all;
 
       &,
       a {

--- a/scss/civicrm/contact/_detail.scss
+++ b/scss/civicrm/contact/_detail.scss
@@ -1,3 +1,12 @@
+/*
+  stylelint-disable max-nesting-depth,
+  selector-max-compound-selectors,
+  selector-no-qualifying-type,
+  selector-max-id,
+  scss/at-extend-no-missing-placeholder,
+  property-no-vendor-prefix
+*/
+
 @import 'collapse';
 @import 'tooltip';
 


### PR DESCRIPTION
## Overview
In the contact summary page, if the Name of the Location Type is too long and it is without any Spaces, it breaks the UI. This PR fixes the same.

## Before
![2021-07-14 at 1 38 PM](https://user-images.githubusercontent.com/5058867/125586865-4aeb7f11-5ed1-4d9c-9732-b0b9e746ffe5.png)

## After
![2021-07-14 at 1 37 PM](https://user-images.githubusercontent.com/5058867/125586805-50c0af5b-19a0-4922-bb5e-1a1b128daff5.png)

## Technical Details
Added `word-break: break-all;` to fix this issue.
Also Ignore Linter rules are added for the `scss/civicrm/contact/_detail.scss` file. As this file overrides core styles, it is necessary to ignore these rules.

## Backstop JS Report
https://github.com/compucorp/backstopjs-config/actions/runs/1029463378