### PR TITLE
Labels: break-word instead of break-all, to avoid cutting a word

### DIFF
--- a/scss/civicrm/contact/_detail.scss
+++ b/scss/civicrm/contact/_detail.scss
@@ -60,7 +60,7 @@
   div.crm-summary-row {
     div.crm-label {
       font-weight: $crm-font-weight-bold;
-      word-break: break-all;
+      word-break: break-word;
 
       &,
       a {


### PR DESCRIPTION
## Overview

Long labels might sometimes be cut mid-word, which looks a bit odd.

## Before

![shoreditch-2021-08-12_15-49](https://user-images.githubusercontent.com/254741/129260012-1cc3dbf4-39fe-442f-9487-995a22b64b9f.png)

## After

![image](https://user-images.githubusercontent.com/254741/129260078-b535664c-b040-4a77-ab2f-253e61992d10.png)

## Technical Details

`break-word` instead of `break-all`

## Backstop JS Report

## Comments

