### PR TITLE
MAE-633: Regenerate CiviCRM menu if it is empty

### DIFF
--- a/shoreditch.php
+++ b/shoreditch.php
@@ -199,5 +199,13 @@ function shoreditch_civicrm_navigationMenu(&$menu) {
  *   TRUE if Shoreditch is the active theme.
  */
 function _shoreditch_isActive() {
+  // The Job civicrm_api3_job_cleanup can clear the DB cache, causing the
+  // CiviCRM menu to be empty on the first load after the command ran.
+  // Without the menu, the getActiveThemeKey is unable to detect the current
+  // theme. This condition ensures the menu is filled.
+  if (!CRM_Core_DAO::checkTableHasData(CRM_Core_DAO_Menu::getTableName())) {
+    CRM_Core_Menu::store(FALSE);
+  }
+
   return Civi::service('themes')->getActiveThemeKey() === 'shoreditch';
 }


### PR DESCRIPTION
## Overview
This PR solves the theme problem that appears after clearing the DB Cache

## Before
The problem observed consists of the Shoreditch theme not loading correctly at some intervals, but that situation gets solved after refreshing the page. This is an example of how the interface looks:
![Screenshot 2021-12-08 at 13 21 14](https://user-images.githubusercontent.com/74304572/158545401-13d828e3-052b-4fb0-beb9-65a6c40c6afe.png)
The error can be reproduced by executing the Job that clears the DB Cache:
![capture_broken](https://user-images.githubusercontent.com/74304572/158545608-4ab29298-d3c9-4450-8a22-7f5523e531e1.gif)
**Note** The job usually runs by a console, not using the "Execute now" in the UI as I did on the demo, then the page refresh that we are seeing is not performed. This causes that the next user to access the site after the cron runs in the background sees the error on the theme.

## After
The error after clearing DB Cache does not appear anymore:
![capture_fixed](https://user-images.githubusercontent.com/74304572/158545888-222ba7e9-090d-4db4-8b18-872ffdb2fc1e.gif)

## Technical Details
The function `_shoreditch_isActive` depends on [Civi::service('themes')->getActiveThemeKey()](https://github.com/civicrm/civicrm-core/blob/5.35.2/Civi/Core/Themes.php#L68) to determine if it is active.
This is, in turn, depending on [DrupalBase method](https://github.com/civicrm/civicrm-core/blob/5.35.2/CRM/Utils/System/DrupalBase.php#L658) for detecting if the path corresponds to a frontend or backend theme:
```php
      $config = \CRM_Core_Config::singleton();
      $settingKey = $config->userSystem->isFrontEndPage() ? 'theme_frontend' : 'theme_backend';
```
Since the first moment after the Db Cache clears the menu is empty, the condition of the mentioned method:
```php
    $path = CRM_Utils_System::currentPath();

    // Get the menu for above URL.
    $item = CRM_Core_Menu::get($path);
    // In case the URL is not a civicrm page (a drupal page) we set the FE theme to TRUE - covering the corner case
    return (empty($item) || !empty($item['is_public']));
```
Returns true (since `empty($item) === TRUE`).

For solving this we have two options:
- We detect if it is frontend using another method, like the one suggested [on this comment](https://github.com/civicrm/civicrm-core/blob/5.35.2/Civi/Core/Themes.php#L70)
- We check if the menu is empty and regenerate it.

In this PR I go for the second option, which is easier and acceptable in performance terms. 

## Backstop JS Report
- https://github.com/compucorp/backstopjs-config/actions/runs/1991524616 Ony 4 fails, which corresponds to delays on page load or order in fields. 
