### PR TITLE
CATL-2243: Fix quick search result dropdown

### DIFF
--- a/scss/civicrm/common/_main-menu.scss
+++ b/scss/civicrm/common/_main-menu.scss
@@ -108,6 +108,7 @@
     font-size: $font-size-base;
     padding: $crm-main-menu-padding-base 0;
 
+    .ui-menu-item-uiMenuItemWrapper,
     .ui-menu-item-wrapper {
       padding: $crm-main-menu-padding-small ($crm-main-menu-padding-base * 2) $crm-main-menu-padding-small $crm-main-menu-padding-base;
     }


### PR DESCRIPTION
## Overview
This PR fixes the issue with missing spacing in the quick search result dropdown, this issue is caused by a change in the dropdown item CSS class in the recent CiviCRM version.

The CSS class used to be `ui-menu-item-wrapper` but now `ui-menu-item-uiMenuItemWrapper`, added support for the two classes to ensure backward compatibility.

## Before
On an older version of CiviCRM, 5.35.2
<img width="1440" alt="Screenshot 2022-07-22 at 08 08 40" src="https://user-images.githubusercontent.com/85277674/180389691-cbc14874-38d5-40eb-9d87-5e9e85a23a35.png">

On a newer version of CiviCRM, 5.39.1
<img width="1440" alt="Screenshot 2022-07-22 at 08 07 46" src="https://user-images.githubusercontent.com/85277674/180389608-ff72be0f-a343-4d58-a213-b85ccdf7d24c.png">

## After
On a newer version of CiviCRM, 5.39.1
<img width="1440" alt="Screenshot 2022-07-22 at 09 21 55" src="https://user-images.githubusercontent.com/85277674/180396679-849c7dc0-9673-403a-bdb1-6f5eea064cff.png">

## Backstop JS Report
[Backstop JS report here](https://github.com/compucorp/backstopjs-config/actions/runs/2717988065)