### PR TITLE
Add class crm-disabled

### DIFF
--- a/scss/civicrm/common/_base.scss
+++ b/scss/civicrm/common/_base.scss
@@ -65,7 +65,7 @@
         color: $crm-copy !important;
       }
 
-      &.disabled {
+      &.disabled, &.crm-disabled {
         color: $crm-gray-matte !important;
         cursor: default;
 


### PR DESCRIPTION
Adds crm-disabled to match this PR in Core, which makes the "disabled" links clickable by changing disabled class to crm-disabled, since disabled has a different meaning in Bootstrap.

Visually nothing is changed, this merely applies the style for
.crm-container table td .btn-slide-active ul.panel li .crm-hover-button.action-item.disabled
to
.crm-container table td .btn-slide-active ul.panel li .crm-hover-button.action-item.crm-disabled
as well.