### PR TITLE
MAE-965: Align button with help icon on contacts group page

### DIFF
--- a/scss/civicrm/common/_buttons.scss
+++ b/scss/civicrm/common/_buttons.scss
@@ -447,3 +447,7 @@ button {
 #bootstrap-theme .crm-button:not(:last-child) {
   margin-right: $crm-gap-small * 2;
 }
+
+.crm-submit-buttons .helpicon {
+  float: none;
+}


### PR DESCRIPTION
## Overview
This PR aligns the button with their help icon on the contacts group page.

## Before
Behaviour in the latest CiviCRM (tested with 5.51.3) with Shoreditch, the help icons are away from the buttons.
![image](https://user-images.githubusercontent.com/85277674/204535131-7a5bad65-98f7-474f-9d1b-7887e8bbe235.png)



## After
The default behaviour in CiviCRM without Shoreditch.
<img width="995" alt="Screenshot 2022-11-29 at 12 58 55" src="https://user-images.githubusercontent.com/85277674/204533071-124087fa-b7e6-4dfd-a98e-6dcab1e30ba9.png">

Behaviour in the latest CiviCRM (tested with 5.51.3) with Shoreditch.
<img width="1176" alt="Screenshot 2022-11-29 at 12 59 06" src="https://user-images.githubusercontent.com/85277674/204533184-f07253e2-0577-42c6-bb6d-d8bc9b714643.png">


## Technical Details
In this https://github.com/civicrm/civicrm-core/commit/044fc18f4a8afdcfd2ef1a552d05be09a6f3b1b6 included in CiviCRM [5.42.0](https://github.com/civicrm/civicrm-core/releases/tag/5.42.0), buttons in the contacts group page were added to a single div group and a CSS rule to float the icon was added, this is causing an issue in Shoreditch theme forcing the helo icons to float away from their respective buttons.

We simply set the float to none, for the help icons to be rightly placed beside their respective buttons.

## Backstop JS Report
https://github.com/compucorp/backstopjs-config/actions/runs/3574589840