### PR TITLE
Fix padding for select2

### DIFF
--- a/scss/jquery/overrides/_select2.scss
+++ b/scss/jquery/overrides/_select2.scss
@@ -102,7 +102,7 @@ $crm-jquery-select2-search-items-label-padding: 5px 10px;
       border-color: $brand-primary;
       border-radius: $border-radius-base;
       font-size: $font-size-base;
-      padding: 3px 25px 3px 5px;
+      padding: 3px 25px 3px 5px !important;
       word-break: break-all;
 
       &.select2-search-choice-focus {


### PR DESCRIPTION
## Overview
civicrm.css is more specific than custom-civicrm.css for select2 multi-select items, so the padding from civicrm.css applies, which looks bad as shown below. Adding !important fixes this. Issue #480.

Steps to reproduce:
Add custom-civicrm.css Resource URL
Add multi-select field in profile to Contribution Page
View Page

## Before
<img width="565" alt="image" src="https://github.com/civicrm/org.civicrm.shoreditch/assets/25517556/59128234-a528-4ac5-bb8c-35f735a15ee2">

## After
<img width="565" alt="image" src="https://github.com/civicrm/org.civicrm.shoreditch/assets/25517556/522f0c65-472b-4b92-8c77-aea5dcb61f6a">
