### PR TITLE
Untested PR: fixes accordion SCSS for Civi > 5.69

### DIFF
--- a/scss/civicrm/common/_accordions.scss
+++ b/scss/civicrm/common/_accordions.scss
@@ -2,25 +2,16 @@
   border-radius: 0 !important;
 }
 
-.crm-accordion-header {
+.crm-accordion-header,
+.crm-accordion-bold > summary {
   @include accordion-header;
 
   &:not(.crm-master-accordion-header) {
     border-bottom: 1px solid $crm-grayblue-dark;
     font-size: $font-size-base !important;
     font-weight: $crm-font-weight-h3;
-  }
+    padding: 16px 20px !important;
 
-  &.crm-master-accordion-header {
-    background: $brand-primary !important;
-    border-radius: $border-radius-base $border-radius-base 0 0 !important;
-    color: $crm-white !important;
-    font-size: $font-size-h2;
-    font-weight: $crm-font-weight-h3 !important;
-
-    &::before {
-      color: $crm-white;
-    }
   }
 
   .crm-close-accordion {
@@ -39,6 +30,21 @@
       color: $crm-white;
       opacity: 0.8;
     }
+  }
+}
+
+.crm-master-accordion-header,
+.crm-accordion-light > summary {
+  background: $brand-primary !important;
+  border-radius: $border-radius-base $border-radius-base 0 0 !important;
+  color: $crm-white !important;
+  font-size: $font-size-h2;
+  font-weight: $crm-font-weight-h3 !important;
+  padding: 16px 20px !important;
+
+
+  &::before {
+    color: $crm-white;
   }
 }
 
@@ -67,11 +73,47 @@
   }
 }
 
-.crm-master-accordion-header + .crm-accordion-body {
+// repeats above pattern for new markup
+
+details {
+  border-radius: 0;
+  margin-bottom: 0;
+
+  &:[open] {
+    summary {
+      &::before {
+        content: '\f107';
+      }
+    }
+  }
+
+  &:not([open]) {
+    summary {
+      &::before {
+        content: '\f105';
+      }
+    }
+  }
+
+  &.crm-accordion-light:not([open]) {
+    summary {
+      border-radius: $border-radius-base !important;
+    }
+  }
+}
+
+// Remove padding for accordions in accordions
+details details {
+  padding: 0;
+}
+
+.crm-master-accordion-header + .crm-accordion-body,
+.crm-accordion-light > .crm-accordion-body {
   border-radius: 0 0 $border-radius-base $border-radius-base !important;
 }
 
-.crm-accordion-header:not(.crm-master-accordion-header) + .crm-accordion-body {
+.crm-accordion-header:not(.crm-master-accordion-header) + .crm-accordion-body,
+.crm-accordion-bold > .crm-accordion-body {
   box-shadow: $crm-box-shadow-inset;
   padding: 15px !important;
 


### PR DESCRIPTION
### Untested, but offered to resolve UI issues on Civi installs after 5.69.

Closing a major accessibility shortfall, accordion markup across Civi has been upgraded between 5.69 + 5.72 to make them keyboard and screen-reader friendly.

This PR adds the new changes as described in https://lab.civicrm.org/dev/user-interface/-/wikis/DINO:-Notify-themes-+-New-theme/changes-in-5.69, in order to preserve Shoreditch styles on the new accordions.

However, I've been unable to fully install Shoreditch to compile these changes into css locally so can't test this PR. However I have tested a largely similar PR in The Island theme: https://lab.civicrm.org/extensions/theisland/-/merge_requests/9.

## Before
Accordions match Greenwich styling…

<img width="1106" alt="image" src="https://github.com/civicrm/org.civicrm.shoreditch/assets/1175967/f980ca7a-e5dd-4929-9eb3-7f7a25157e9e">
<img width="1384" alt="image" src="https://github.com/civicrm/org.civicrm.shoreditch/assets/1175967/acb1f184-1f57-4a15-950a-e864a258cd6d">

## After
They don't…

<img width="1165" alt="image" src="https://github.com/civicrm/org.civicrm.shoreditch/assets/1175967/8c802447-f458-4c7f-b4e3-d0b52d9bf56b">
<img width="1435" alt="image" src="https://github.com/civicrm/org.civicrm.shoreditch/assets/1175967/a312124f-4d57-4b7d-b0db-7dd864748c88">

## Technical Details
Screengrabs are from [the changes in The Island](https://lab.civicrm.org/extensions/theisland/-/merge_requests/9), and reflect the expected appearance after testing. 