### PR TITLE
PROD-190: Ensure alert is visible when modal is displayed

### DIFF
--- a/scss/civicrm/common/_block-shadows.scss
+++ b/scss/civicrm/common/_block-shadows.scss
@@ -6,7 +6,8 @@
  * then the shadows will overlap. The method makes it visually look like there is
  * just a single shadow underneath the pair.
  */
-
+ 
+/* stylelint-disable selector-max-id, selector-max-compound-selectors */
 @mixin block-shadows-for-pair () {
   position: relative;
 
@@ -67,6 +68,11 @@
 #crm-container {
   position: relative;
   z-index: 1;
+}
+
+// Allow alert have higher z-index than modal
+.ui-dialog-open #crm-container {
+  z-index: unset;
 }
 
 @include block-shadows-for-h3-crm-form-block-pair();


### PR DESCRIPTION
## Overview
Previously, when an error or alert occurred, the toast message would be obscured by the modal, potentially causing users to miss it and preventing them from dismissing it. 

## Before
The alert box was positioned behind the modal overlay, making it less visible and inaccessible for dismissal by the user.
![Before Screenshot](https://github.com/civicrm/org.civicrm.shoreditch/assets/85277674/50bae999-f3c6-4758-9e0f-fce2ee31acc2)

## After
Now, the alert box appears above the modal overlay and can be dismissed by the user.
![After Screenshot](https://github.com/civicrm/org.civicrm.shoreditch/assets/85277674/b67a9ade-9c9c-4814-a5fb-7315383f3e22)