### PR TITLE
Make the New Mailing Subject field 100% of container width

### DIFF
--- a/scss/civicrm/mailing/pages/_mailing-create.scss
+++ b/scss/civicrm/mailing/pages/_mailing-create.scss
@@ -1,0 +1,3 @@
+.crm-mosaico-page.ng-scope #inputSubject {
+  width:100% !important;
+}


### PR DESCRIPTION
## Overview
Make the New Mailing Subject field 100% of container width

## Before
It's too small.

## After
It's full width.

## Technical Details
Just one new SCSS file "_mailing-create.scss"
